### PR TITLE
fixed a bug when generating shares with group_threshold=1

### DIFF
--- a/shamir_mnemonic/__init__.py
+++ b/shamir_mnemonic/__init__.py
@@ -574,6 +574,10 @@ def generate_mnemonics(
 
     group_shares = _split_secret(group_threshold, len(groups), encrypted_master_secret)
 
+    if group_threshold == 1 and len(groups) > 1:
+        group_secret = group_shares[0][1]
+        group_shares = [(i, group_secret) for i in range(len(groups))]
+
     return [
         [
             encode_mnemonic(

--- a/shamir_mnemonic/__init__.py
+++ b/shamir_mnemonic/__init__.py
@@ -307,7 +307,7 @@ def _split_secret(threshold, share_count, shared_secret):
 
     # If the threshold is 1, then the digest of the shared secret is not used.
     if threshold == 1:
-        return [(0, shared_secret)]
+        return [(i, shared_secret) for i in range(share_count)]
 
     random_share_count = threshold - 2
 
@@ -573,10 +573,6 @@ def generate_mnemonics(
     )
 
     group_shares = _split_secret(group_threshold, len(groups), encrypted_master_secret)
-
-    if group_threshold == 1 and len(groups) > 1:
-        group_secret = group_shares[0][1]
-        group_shares = [(i, group_secret) for i in range(len(groups))]
 
     return [
         [

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -74,28 +74,10 @@ def test_group_sharing():
         shamir.combine_mnemonics(mnemonics[0][1:4])
 
 
-def test_group_sharing_threshold_1():
-    group_threshold = 1
-    group_sizes = (5, 3, 5, 1)
-    member_thresholds = (3, 2, 2, 1)
-    mnemonics = shamir.generate_mnemonics(
-        group_threshold, list(zip(member_thresholds, group_sizes)), MS
-    )
-
-    # Test all valid combinations of mnemonics.
-    for groups in combinations(zip(mnemonics, member_thresholds), group_threshold):
-        for group1_subset in combinations(groups[0][0], groups[0][1]):
-            mnemonic_subset = list(group1_subset)
-            shuffle(mnemonic_subset)
-            assert MS == shamir.combine_mnemonics(mnemonic_subset)
-
-    # Minimal sets of mnemonics.
-    assert MS == shamir.combine_mnemonics(
-        [mnemonics[2][0], mnemonics[2][2]]
-    )
-    assert MS == shamir.combine_mnemonics(
-        [mnemonics[3][0]]
-    )
+def test_all_groups_exist():
+    for threshold in (1,2,5):
+        mnemonics = shamir.generate_mnemonics(threshold, [(2, 5)] * 5, MS)
+        assert len(mnemonics) == 5
 
 
 def test_invalid_sharing():

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -74,6 +74,30 @@ def test_group_sharing():
         shamir.combine_mnemonics(mnemonics[0][1:4])
 
 
+def test_group_sharing_threshold_1():
+    group_threshold = 1
+    group_sizes = (5, 3, 5, 1)
+    member_thresholds = (3, 2, 2, 1)
+    mnemonics = shamir.generate_mnemonics(
+        group_threshold, list(zip(member_thresholds, group_sizes)), MS
+    )
+
+    # Test all valid combinations of mnemonics.
+    for groups in combinations(zip(mnemonics, member_thresholds), group_threshold):
+        for group1_subset in combinations(groups[0][0], groups[0][1]):
+            mnemonic_subset = list(group1_subset)
+            shuffle(mnemonic_subset)
+            assert MS == shamir.combine_mnemonics(mnemonic_subset)
+
+    # Minimal sets of mnemonics.
+    assert MS == shamir.combine_mnemonics(
+        [mnemonics[2][0], mnemonics[2][2]]
+    )
+    assert MS == shamir.combine_mnemonics(
+        [mnemonics[3][0]]
+    )
+
+
 def test_invalid_sharing():
     # Short master secret.
     with pytest.raises(ValueError):


### PR DESCRIPTION
The _split_secret function only returns a single share when you pass in a group_threshold of 1. This change makes spreads that single share around to all of the groups in the case that the group_threshold is 1, but there is more than one group.