### PR TITLE
Use `python3 -m pip` instead of `pip`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ With pip from GitHub:
 
 .. code-block:: console
 
-    $ pip3 install https://github.com/trezor/python-shamir-mnemonic
+    $ python3 -m pip install https://github.com/trezor/python-shamir-mnemonic
 
 From local checkout for development:
 


### PR DESCRIPTION
Fixes #20.