### PR TITLE
Use secrets module instead of os.urandom.

### DIFF
--- a/shamir_mnemonic/__init__.py
+++ b/shamir_mnemonic/__init__.py
@@ -21,7 +21,8 @@
 
 import hashlib
 import hmac
-import os
+import os.path
+import secrets
 
 
 class MnemonicError(Exception):
@@ -85,7 +86,7 @@ SECRET_INDEX = 255
 DIGEST_INDEX = 254
 """The index of the share containing the digest of the shared secret."""
 
-RANDOM_BYTES = os.urandom
+RANDOM_BYTES = secrets.token_bytes
 """Source of random bytes. Can be overriden for deterministic testing."""
 
 

--- a/shamir_mnemonic/cli.py
+++ b/shamir_mnemonic/cli.py
@@ -1,4 +1,4 @@
-import os
+import secrets
 import sys
 from collections import defaultdict, namedtuple
 
@@ -99,7 +99,7 @@ def create(scheme, groups, threshold, exponent, master_secret, passphrase, stren
                 "master_secret", f"Secret bytes must be hex encoded"
             ) from e
     else:
-        secret_bytes = os.urandom(strength // 8)
+        secret_bytes = secrets.token_bytes(strength // 8)
 
     secret_hex = style(secret_bytes.hex(), bold=True)
     click.echo(f"Using master secret: {secret_hex}")


### PR DESCRIPTION
Although both of them are using the same implementation as of python 3.8
[1], the python docs recommend using the secrets module for generating
secrets, and its usage makes it clearer for reviewers that a
cryptographically strong source of randomness is used.

[1] https://docs.python.org/3/library/random.html#random.SystemRandom