### PR TITLE
add main.py to be able to run as script from checkout

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+""" From https://stackoverflow.com/a/16985066 to resolve `ImportError: attempted relative import with no known parent package` """
+from shamir_mnemonic.cli import cli
+
+def main():
+    cli()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
So far, after `git clone` you would not be able to run and debug the source code obtained as relative imports would fail: 
```
$python shamir_mnemonic/cli.py
  File "shamir_mnemonic/cli.py", line 10, in <module>
    from .constants import GROUP_PREFIX_LENGTH_WORDS
ImportError: attempted relative import with no known parent package
```

Including the script adapter for the package like this, cli script runs nice and smoothly.