### PR TITLE
Interface improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ You can specify a custom scheme. For example, to create three groups, with 2-of-
 
 .. code-block:: console
 
-    $ shamir create custom --threshold 3 --group 2 3 --group 2 5 --group 4 5
+    $ shamir create custom --group-threshold 3 --group 2 3 --group 2 5 --group 4 5
 
 Use :code:`shamir --help` or :code:`shamir create --help` to see all available options.
 

--- a/generate_vectors.py
+++ b/generate_vectors.py
@@ -3,7 +3,6 @@ import json
 import random
 
 import attr
-
 from shamir_mnemonic import constants, rs1024, shamir, wordlist
 from shamir_mnemonic.share import Share
 

--- a/shamir_mnemonic/__init__.py
+++ b/shamir_mnemonic/__init__.py
@@ -2,6 +2,7 @@
 
 from .cipher import decrypt, encrypt
 from .shamir import (
+    EncryptedMasterSecret,
     combine_mnemonics,
     decode_mnemonics,
     generate_mnemonics,
@@ -19,6 +20,7 @@ __all__ = [
     "generate_mnemonics",
     "split_ems",
     "recover_ems",
+    "EncryptedMasterSecret",
     "MnemonicError",
     "Share",
 ]

--- a/shamir_mnemonic/__init__.py
+++ b/shamir_mnemonic/__init__.py
@@ -1,15 +1,24 @@
 # flake8: noqa
 
 from .cipher import decrypt, encrypt
-from .shamir import combine_mnemonics, generate_mnemonics, recover_ems, split_ems
+from .shamir import (
+    combine_mnemonics,
+    decode_mnemonics,
+    generate_mnemonics,
+    recover_ems,
+    split_ems,
+)
+from .share import Share
 from .utils import MnemonicError
 
 __all__ = [
     "encrypt",
     "decrypt",
     "combine_mnemonics",
+    "decode_mnemonics",
     "generate_mnemonics",
     "split_ems",
     "recover_ems",
     "MnemonicError",
+    "Share",
 ]

--- a/shamir_mnemonic/cli.py
+++ b/shamir_mnemonic/cli.py
@@ -145,7 +145,7 @@ def create(
 
 FINISHED = style("\u2713", fg="green", bold=True)
 EMPTY = style("\u2717", fg="red", bold=True)
-INPROGRESS = style("\u26ab", fg="yellow", bold=True)
+INPROGRESS = style("\u25cf", fg="yellow", bold=True)
 
 
 def error(s: str) -> None:

--- a/shamir_mnemonic/recovery.py
+++ b/shamir_mnemonic/recovery.py
@@ -5,7 +5,7 @@ import attr
 
 from .constants import GROUP_PREFIX_LENGTH_WORDS
 from .shamir import ShareGroup, recover_ems
-from .share import Share, ShareSetParameters
+from .share import Share, ShareCommonParameters
 from .utils import MnemonicError
 
 UNDETERMINED = -1
@@ -17,7 +17,7 @@ class RecoveryState:
     def __init__(self) -> None:
         self.last_share: Optional[Share] = None
         self.groups: Dict[int, ShareGroup] = defaultdict(ShareGroup)
-        self.parameters: Optional[ShareSetParameters] = None
+        self.parameters: Optional[ShareCommonParameters] = None
 
     def group_prefix(self, group_index: int) -> str:
         """Return three starting words of a given group."""

--- a/shamir_mnemonic/recovery.py
+++ b/shamir_mnemonic/recovery.py
@@ -39,14 +39,14 @@ class RecoveryState:
             return 0, UNDETERMINED
 
         share = next(iter(group))
-        return len(group), share.threshold
+        return len(group), share.member_threshold
 
     def group_is_complete(self, group_index: int) -> bool:
         """Check whether a given group is already complete."""
-        shares, threshold = self.group_status(group_index)
-        if threshold == UNDETERMINED:
+        shares, member_threshold = self.group_status(group_index)
+        if member_threshold == UNDETERMINED:
             return False
-        return shares >= threshold
+        return shares >= member_threshold
 
     def groups_complete(self) -> int:
         """Return the number of groups that are already complete."""

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -70,6 +70,13 @@ class ShareGroup:
     def to_raw_shares(self) -> List[RawShare]:
         return [RawShare(s.index, s.value) for s in self.shares]
 
+    def get_minimal_group(self) -> "ShareGroup":
+        group = ShareGroup()
+        group.shares = set(
+            share for _, share in zip(range(self.member_threshold()), self.shares)
+        )
+        return group
+
     def common_parameters(self) -> ShareSetParameters:
         return next(iter(self.shares)).common_parameters()
 

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -44,7 +44,7 @@ class RawShare(NamedTuple):
 
 
 class ShamirGroup(NamedTuple):
-    threshold: int
+    member_threshold: int
     shares: Set[Share]
 
     def to_raw_shares(self) -> List[RawShare]:
@@ -198,9 +198,9 @@ def _decode_mnemonics(
         share = Share.from_mnemonic(mnemonic)
         all_group_params.add(share.common_parameters())
         group = groups.setdefault(
-            share.group_index, ShamirGroup(share.threshold, set())
+            share.group_index, ShamirGroup(share.member_threshold, set())
         )
-        if group.threshold != share.threshold:
+        if group.member_threshold != share.member_threshold:
             raise MnemonicError(
                 "Invalid set of mnemonics. All mnemonics in a group must have "
                 "the same member threshold."
@@ -365,18 +365,18 @@ def recover_ems(mnemonics: Iterable[str]) -> Tuple[int, int, bytes]:
             f"but {len(groups)} were provided."
         )
 
-    for threshold, shares in groups.values():
-        if len(shares) != threshold:
+    for member_threshold, shares in groups.values():
+        if len(shares) != member_threshold:
             share_words = next(iter(shares)).words()
             prefix = " ".join(share_words[:GROUP_PREFIX_LENGTH_WORDS])
             raise MnemonicError(
                 "Wrong number of mnemonics. "
-                f'Expected {threshold} mnemonics starting with "{prefix} ...", '
+                f'Expected {member_threshold} mnemonics starting with "{prefix} ...", '
                 f"but {len(shares)} were provided."
             )
 
     group_shares = [
-        RawShare(group_index, _recover_secret(group.threshold, group.to_raw_shares()))
+        RawShare(group_index, _recover_secret(group.member_threshold, group.to_raw_shares()))
         for group_index, group in groups.items()
     ]
 

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -319,7 +319,7 @@ def split_ems(
                 member_index,
                 member_threshold,
                 value,
-            ).mnemonic()
+            )
             for member_index, value in _split_secret(
                 member_threshold, member_count, group_secret
             )
@@ -370,7 +370,8 @@ def generate_mnemonics(
     encrypted_master_secret = EncryptedMasterSecret.from_master_secret(
         master_secret, passphrase, identifier, iteration_exponent
     )
-    return split_ems(group_threshold, groups, encrypted_master_secret)
+    grouped_shares = split_ems(group_threshold, groups, encrypted_master_secret)
+    return [[share.mnemonic() for share in group] for group in grouped_shares]
 
 
 def recover_ems(groups: Dict[int, ShareGroup]) -> EncryptedMasterSecret:

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -21,7 +21,7 @@
 
 import hmac
 import secrets
-from typing import Dict, Iterable, List, NamedTuple, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, NamedTuple, Sequence, Set, Tuple
 
 from . import cipher
 from .constants import (
@@ -43,15 +43,44 @@ class RawShare(NamedTuple):
     data: bytes
 
 
-class ShamirGroup(NamedTuple):
-    member_threshold: int
-    shares: Set[Share]
+class ShareGroup:
+    def __init__(self) -> None:
+        self.shares: Set[Share] = set()
+
+    def __iter__(self) -> Iterable[Share]:
+        return iter(self.shares)
+
+    def __len__(self) -> int:
+        return len(self.shares)
+
+    def __bool__(self) -> bool:
+        return bool(self.shares)
+
+    def __contains__(self, obj: Any) -> bool:
+        return obj in self.shares
+
+    def add(self, share: Share) -> None:
+        if self.shares and self.member_threshold() != share.member_threshold:
+            raise MnemonicError(
+                "Invalid set of mnemonics. All mnemonics in a group must have "
+                "the same member threshold."
+            )
+        self.shares.add(share)
 
     def to_raw_shares(self) -> List[RawShare]:
         return [RawShare(s.index, s.value) for s in self.shares]
 
     def common_parameters(self) -> ShareSetParameters:
         return next(iter(self.shares)).common_parameters()
+
+    def member_threshold(self) -> int:
+        return next(iter(self.shares)).member_threshold
+
+    def is_complete(self) -> int:
+        if self.shares:
+            return len(self.shares) >= self.member_threshold()
+        else:
+            return False
 
 
 class EncryptedMasterSecret:
@@ -217,21 +246,14 @@ def _recover_secret(threshold: int, shares: Sequence[RawShare]) -> bytes:
     return shared_secret
 
 
-def decode_mnemonics(mnemonics: Iterable[str]) -> Dict[int, ShamirGroup]:
+def decode_mnemonics(mnemonics: Iterable[str]) -> Dict[int, ShareGroup]:
     all_group_params = set()
-    groups: Dict[int, ShamirGroup] = {}
+    groups: Dict[int, ShareGroup] = {}
     for mnemonic in mnemonics:
         share = Share.from_mnemonic(mnemonic)
         all_group_params.add(share.common_parameters())
-        group = groups.setdefault(
-            share.group_index, ShamirGroup(share.member_threshold, set())
-        )
-        if group.member_threshold != share.member_threshold:
-            raise MnemonicError(
-                "Invalid set of mnemonics. All mnemonics in a group must have "
-                "the same member threshold."
-            )
-        group.shares.add(share)
+        group = groups.setdefault(share.group_index, ShareGroup())
+        group.add(share)
 
     if len(all_group_params) != 1:
         raise MnemonicError(
@@ -351,7 +373,7 @@ def generate_mnemonics(
     return split_ems(group_threshold, groups, encrypted_master_secret)
 
 
-def recover_ems(groups: Dict[int, ShamirGroup]) -> EncryptedMasterSecret:
+def recover_ems(groups: Dict[int, ShareGroup]) -> EncryptedMasterSecret:
     """
     Combine shares, recover metadata and the Encrypted Master Secret.
 
@@ -361,7 +383,7 @@ def recover_ems(groups: Dict[int, ShamirGroup]) -> EncryptedMasterSecret:
     Secret to a later time.
 
     :param groups: Set of shares classified into groups.
-    :return: Identifier, iteration exponent, and Encrypted Master Secret
+    :return: Encrypted Master Secret
     """
 
     if not groups:
@@ -382,19 +404,20 @@ def recover_ems(groups: Dict[int, ShamirGroup]) -> EncryptedMasterSecret:
             f"but {len(groups)} were provided."
         )
 
-    for member_threshold, shares in groups.values():
-        if len(shares) != member_threshold:
-            share_words = next(iter(shares)).words()
+    for group in groups.values():
+        if len(group) != group.member_threshold():
+            share_words = next(iter(group)).words()
             prefix = " ".join(share_words[:GROUP_PREFIX_LENGTH_WORDS])
             raise MnemonicError(
                 "Wrong number of mnemonics. "
-                f'Expected {member_threshold} mnemonics starting with "{prefix} ...", '
-                f"but {len(shares)} were provided."
+                f'Expected {group.member_threshold()} mnemonics starting with "{prefix} ...", '
+                f"but {len(group)} were provided."
             )
 
     group_shares = [
         RawShare(
-            group_index, _recover_secret(group.member_threshold, group.to_raw_shares())
+            group_index,
+            _recover_secret(group.member_threshold(), group.to_raw_shares()),
         )
         for group_index, group in groups.items()
     ]

--- a/shamir_mnemonic/share.py
+++ b/shamir_mnemonic/share.py
@@ -46,7 +46,7 @@ class Share:
     group_threshold: int
     group_count: int
     index: int
-    threshold: int
+    member_threshold: int
     value: bytes
 
     def common_parameters(self) -> ShareSetParameters:
@@ -74,7 +74,7 @@ class Share:
         val <<= 4
         val += self.index
         val <<= 4
-        val += self.threshold - 1
+        val += self.member_threshold - 1
         # group parameters are 2 words
         return _int_to_word_indices(val, 2)
 
@@ -126,7 +126,7 @@ class Share:
         share_params_data = mnemonic_data[ID_EXP_LENGTH_WORDS : ID_EXP_LENGTH_WORDS + 2]
         share_params_int = _int_from_word_indices(share_params_data)
         share_params = int_to_indices(share_params_int, 5, 4)
-        group_index, group_threshold, group_count, index, threshold = share_params
+        group_index, group_threshold, group_count, index, member_threshold = share_params
 
         if group_count < group_threshold:
             raise MnemonicError(
@@ -156,6 +156,6 @@ class Share:
             group_threshold + 1,
             group_count + 1,
             index,
-            threshold + 1,
+            member_threshold + 1,
             value,
         )

--- a/shamir_mnemonic/share.py
+++ b/shamir_mnemonic/share.py
@@ -29,11 +29,24 @@ def _int_from_word_indices(indices: Iterable[WordIndex]) -> int:
     return value
 
 
-class ShareSetParameters(NamedTuple):
+class ShareCommonParameters(NamedTuple):
+    """Parameters that are common to all shares of a master secret."""
+
     identifier: int
     iteration_exponent: int
     group_threshold: int
     group_count: int
+
+
+class ShareGroupParameters(NamedTuple):
+    """Parameters that are common to all shares of a master secret, which belong to the same group."""
+
+    identifier: int
+    iteration_exponent: int
+    group_index: int
+    group_threshold: int
+    group_count: int
+    member_threshold: int
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -49,13 +62,24 @@ class Share:
     member_threshold: int
     value: bytes
 
-    def common_parameters(self) -> ShareSetParameters:
+    def common_parameters(self) -> ShareCommonParameters:
         """Return values that uniquely identify a matching set of shares."""
-        return ShareSetParameters(
+        return ShareCommonParameters(
             self.identifier,
             self.iteration_exponent,
             self.group_threshold,
             self.group_count,
+        )
+
+    def group_parameters(self) -> ShareGroupParameters:
+        """Return values that uniquely identify shares belonging to the same group."""
+        return ShareGroupParameters(
+            self.identifier,
+            self.iteration_exponent,
+            self.group_index,
+            self.group_threshold,
+            self.group_count,
+            self.member_threshold,
         )
 
     def _encode_id_exp(self) -> List[WordIndex]:

--- a/shamir_mnemonic/share.py
+++ b/shamir_mnemonic/share.py
@@ -126,7 +126,9 @@ class Share:
         share_params_data = mnemonic_data[ID_EXP_LENGTH_WORDS : ID_EXP_LENGTH_WORDS + 2]
         share_params_int = _int_from_word_indices(share_params_data)
         share_params = int_to_indices(share_params_int, 5, 4)
-        group_index, group_threshold, group_count, index, member_threshold = share_params
+        group_index, group_threshold, group_count, index, member_threshold = (
+            share_params
+        )
 
         if group_count < group_threshold:
             raise MnemonicError(

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -85,17 +85,17 @@ def test_group_sharing_threshold_1():
     )
 
     # Test all valid combinations of mnemonics.
-    for group, threshold in zip(mnemonics, member_thresholds):
-        for group_subset in combinations(group, threshold):
+    for group, member_threshold in zip(mnemonics, member_thresholds):
+        for group_subset in combinations(group, member_threshold):
             mnemonic_subset = list(group_subset)
             shuffle(mnemonic_subset)
             assert MS == shamir.combine_mnemonics(mnemonic_subset)
 
 
 def test_all_groups_exist():
-    for threshold in (1, 2, 5):
+    for group_threshold in (1, 2, 5):
         mnemonics = shamir.generate_mnemonics(
-            threshold, [(3, 5), (1, 1), (2, 3), (2, 5), (3, 5)], MS
+            group_threshold, [(3, 5), (1, 1), (2, 3), (2, 5), (3, 5)], MS
         )
         assert len(mnemonics) == 5
         assert len(sum(mnemonics, [])) == 19
@@ -126,7 +126,7 @@ def test_invalid_sharing():
     with pytest.raises(ValueError):
         shamir.generate_mnemonics(2, [(0, 2), (2, 5)], MS)
 
-    # Group with multiple members and threshold 1.
+    # Group with multiple members and member threshold 1.
     with pytest.raises(ValueError):
         shamir.generate_mnemonics(2, [(3, 5), (1, 3), (2, 5)], MS)
 

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -151,10 +151,10 @@ def test_vectors():
 def test_split_ems():
     identifier = 42
     exponent = 1
-    encrypted_master_secret = shamir.encrypt(MS, b"TREZOR", exponent, identifier)
-    mnemonics = shamir.split_ems(
-        1, [(3, 5)], identifier, exponent, encrypted_master_secret
+    encrypted_master_secret = shamir.EncryptedMasterSecret.from_master_secret(
+        MS, b"TREZOR", identifier, exponent
     )
+    mnemonics = shamir.split_ems(1, [(3, 5)], encrypted_master_secret)
 
     recovered = shamir.combine_mnemonics(mnemonics[0][:3], b"TREZOR")
     assert recovered == MS

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -164,6 +164,6 @@ def test_recover_ems():
     mnemonics = shamir.generate_mnemonics(1, [(3, 5)], MS, b"TREZOR")[0]
 
     groups = shamir.decode_mnemonics(mnemonics[:3])
-    identifier, exponent, encrypted_master_secret = shamir.recover_ems(groups)
-    recovered = shamir.decrypt(encrypted_master_secret, b"TREZOR", exponent, identifier)
+    encrypted_master_secret = shamir.recover_ems(groups)
+    recovered = encrypted_master_secret.decrypt(b"TREZOR")
     assert recovered == MS

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -154,9 +154,10 @@ def test_split_ems():
     encrypted_master_secret = shamir.EncryptedMasterSecret.from_master_secret(
         MS, b"TREZOR", identifier, exponent
     )
-    mnemonics = shamir.split_ems(1, [(3, 5)], encrypted_master_secret)
+    grouped_shares = shamir.split_ems(1, [(3, 5)], encrypted_master_secret)
+    mnemonics = [share.mnemonic() for share in grouped_shares[0]]
 
-    recovered = shamir.combine_mnemonics(mnemonics[0][:3], b"TREZOR")
+    recovered = shamir.combine_mnemonics(mnemonics[:3], b"TREZOR")
     assert recovered == MS
 
 

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -4,7 +4,6 @@ from itertools import combinations
 from random import shuffle
 
 import pytest
-
 import shamir_mnemonic as shamir
 from shamir_mnemonic import MnemonicError
 
@@ -164,6 +163,7 @@ def test_split_ems():
 def test_recover_ems():
     mnemonics = shamir.generate_mnemonics(1, [(3, 5)], MS, b"TREZOR")[0]
 
-    identifier, exponent, encrypted_master_secret = shamir.recover_ems(mnemonics[:3])
+    groups = shamir.decode_mnemonics(mnemonics[:3])
+    identifier, exponent, encrypted_master_secret = shamir.recover_ems(groups)
     recovered = shamir.decrypt(encrypted_master_secret, b"TREZOR", exponent, identifier)
     assert recovered == MS


### PR DESCRIPTION
Resolves https://github.com/trezor/python-shamir-mnemonic/issues/33, namely points 5, 6 and 8:

> 5. Introduced an `EncryptedSeed` class and moved the `decrypt` function there. The `recover_ems()` function returns `EncryptedSeed`, which also carries information about the identifier and interation exponent. This is easier to work with if you want to allow the user to supply the passprase later.
> 6. `recover_ems` discards groups that don't meet the member threshold and allows extra shares. In python-shamir-mnemonic if the user provides extra shares, then we fail, which seems like a pointless hassle.
> 8. In some places we used `threshold`, which is ambiguous. Changed to `member_threshold`.

Including:
> In addition to (5), I would also change the signature of `recover_ems` to accept `Share` objects instead of mnemonic strings.

Furthermore:
- The unicode character 26ab (medium black circle), doesn't actually show up colored in my console font :-). So I tried 25cf (black circle) and that finally works fine. Hopefully not just for me.
- Changed input/output of `split_ems()` to resemble output/input of `recover_ems()` more closely, e.g. returning shares instead of mnemonics.
- Enhanced the ShareGroup class with additional methods to make the code which uses it more comprehensible.