### PR TITLE
Recover EncryptedMasterSecrets from arbitrary sequences of Mnemonics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ style_check:
 	black shamir_mnemonic/ *.py --check
 
 analyze: style_check
-	$(PYTHON) -m flake8 --color never -j 1 --max-line-length=100 \
-	  --ignore=W503,E201,E202,E203,E127,E221,E223,E226,E231,E241,E242,E251,E265,E272,E274 \
-	  deepset.py test_deepset.py
+	$(PYTHON) -m flake8 --color never -j 1 \
+	  --ignore=W503,E501,E741 \
+	  shamir_mnemonic test_shamir.py
 
 style:
 	black shamir_mnemonic/ *.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
-PYTHON=python3
-POETRY=poetry
+SHELL		:= /bin/bash
+
+POETRY		:= poetry
+
+VERSION		:= $(shell python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['tool']['poetry']['version'])")
+
+PYTHON		?= $(shell python3 --version >/dev/null 2>&1 && echo python3 || echo python )
+PYTHON_V	:= $(shell $(PYTHON) -c "import sys; print('-'.join((('venv' if sys.prefix != sys.base_prefix else next(iter(filter(None,sys.base_prefix.split('/'))))),sys.platform,sys.implementation.cache_tag)))" 2>/dev/null )
+
+VENV_OPTS	:=
+VENV		:= $(CURDIR)-$(VERSION)-$(PYTHON_V)
 
 
 build:
@@ -40,5 +49,42 @@ style:
 	black shamir_mnemonic/ *.py
 	isort shamir_mnemonic/ *.py
 
+# 
+# Nix and VirtualEnv build, install and activate
+#
+#     Create, start and run commands in "interactive" shell with a python venv's activate init-file.
+# Doesn't allow recursive creation of a venv with a venv-supplied python.  Alters the bin/activate
+# to include the user's .bashrc (eg. Git prompts, aliases, ...).  Use to run Makefile targets in a
+# proper context, for example to obtain a Nix environment containing the proper Python version, create a python venv
+# with the 
+#
+#     make nix-venv-build
+#
+nix-%:
+	@if [ -r flake.nix ]; then \
+	    nix develop $(NIX_OPTS) --command make $*; \
+        else \
+	    nix-shell $(NIX_OPTS) --run "make $*"; \
+	fi
 
-.PHONY: clean clean-build clean-pyc clean-test test style_check style
+venv-%:			$(VENV)
+	@echo; echo "*** Running in $< VirtualEnv: make $*"
+	@bash --init-file $</bin/activate -ic "make $*"
+
+venv:			$(VENV)
+	@echo; echo "*** Activating $< VirtualEnv for Interactive $(SHELL)"
+	@bash --init-file $</bin/activate -i
+
+$(VENV):
+	@[[ "$(PYTHON_V)" =~ "^venv" ]] && ( echo -e "\n\n!!! $@ Cannot start a venv within a venv"; false ) || true
+	@echo; echo "*** Building $@ VirtualEnv..."
+	@rm -rf $@ && $(PYTHON) -m venv $(VENV_OPTS) $@ && sed -i -e '1s:^:. $$HOME/.bashrc\n:' $@/bin/activate \
+	    && source $@/bin/activate \
+	    && make install
+
+print-%:
+	@echo $* = $($*)
+	@echo $*\'s origin is $(origin $*)
+
+
+.PHONY: clean clean-build clean-pyc clean-test test style_check style venv

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VENV		= $(CURDIR)-$(VERSION)-$(PYTHON_V)
 export VENV_OPTS	?=
 export POETRY		?= poetry
 export PYTEST		?= pytest
-export PYTEST_OPTS	?= # -vv --capture=no
+export PYTEST_OPTS	?= # -vv --capture=no --mypy
 
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 SHELL		:= /bin/bash
 
-POETRY		?= poetry
 PYTHON		?= $(shell python3 --version >/dev/null 2>&1 && echo python3 || echo python )
 
 # Ensure $(PYTHON), $(VENV) are re-evaluated at time of expansion, when target 'python' and 'poetry' are known to be available
 PYTHON_V	= $(shell $(PYTHON) -c "import sys; print('-'.join((('venv' if sys.prefix != sys.base_prefix else next(iter(filter(None,sys.base_prefix.split('/'))))),sys.platform,sys.implementation.cache_tag)))" 2>/dev/null )
 
-VENV_OPTS	=
-VENV		= $(CURDIR)-$(shell poetry version -s 2>/dev/null)-$(PYTHON_V)
+VERSION		= $(shell poetry version -s 2>/dev/null)
+VENV		= $(CURDIR)-$(VERSION)-$(PYTHON_V)
+
+# Force export of variables that might be set from command line
+export VENV_OPTS	?=
+export POETRY		?= poetry
+export PYTEST		?= pytest
+export PYTEST_OPTS	?= # -vv --capture=no
 
 
 build:
@@ -41,11 +46,20 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 test:
-	pytest # -vvv --capture=no
+	$(PYTEST) $(PYTEST_OPTS)
+
+# Run all tests with names matching the target string
+unit-%:
+	$(PYTEST) $(PYTEST_OPTS) -k $*
 
 style_check:
 	isort --check-only shamir_mnemonic/ *.py
 	black shamir_mnemonic/ *.py --check
+
+analyze: style_check
+	$(PYTHON) -m flake8 --color never -j 1 --max-line-length=100 \
+	  --ignore=W503,E201,E202,E203,E127,E221,E223,E226,E231,E241,E242,E251,E265,E272,E274 \
+	  deepset.py test_deepset.py
 
 style:
 	black shamir_mnemonic/ *.py

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 test:
-	pytest -vv --capture=no
+	pytest # -vv --capture=no
 
 style_check:
 	isort --check-only shamir_mnemonic/ *.py

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 SHELL		:= /bin/bash
 
-POETRY		:= poetry
-
-VERSION		:= $(shell python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['tool']['poetry']['version'])")
-
+POETRY		?= poetry
 PYTHON		?= $(shell python3 --version >/dev/null 2>&1 && echo python3 || echo python )
-PYTHON_V	:= $(shell $(PYTHON) -c "import sys; print('-'.join((('venv' if sys.prefix != sys.base_prefix else next(iter(filter(None,sys.base_prefix.split('/'))))),sys.platform,sys.implementation.cache_tag)))" 2>/dev/null )
 
-VENV_OPTS	:=
-VENV		:= $(CURDIR)-$(VERSION)-$(PYTHON_V)
+# Ensure $(PYTHON), $(VENV) are re-evaluated at time of expansion, when target 'python' and 'poetry' are known to be available
+PYTHON_V	= $(shell $(PYTHON) -c "import sys; print('-'.join((('venv' if sys.prefix != sys.base_prefix else next(iter(filter(None,sys.base_prefix.split('/'))))),sys.platform,sys.implementation.cache_tag)))" 2>/dev/null )
+
+VENV_OPTS	=
+VENV		= $(CURDIR)-$(shell poetry version -s 2>/dev/null)-$(PYTHON_V)
 
 
 build:
@@ -16,6 +15,9 @@ build:
 
 install:
 	$(POETRY) install
+
+install-dev:
+	$(POETRY) install --with dev
 
 clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 
@@ -39,7 +41,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 test:
-	pytest # -vv --capture=no
+	pytest # -vvv --capture=no
 
 style_check:
 	isort --check-only shamir_mnemonic/ *.py
@@ -55,8 +57,8 @@ style:
 #     Create, start and run commands in "interactive" shell with a python venv's activate init-file.
 # Doesn't allow recursive creation of a venv with a venv-supplied python.  Alters the bin/activate
 # to include the user's .bashrc (eg. Git prompts, aliases, ...).  Use to run Makefile targets in a
-# proper context, for example to obtain a Nix environment containing the proper Python version, create a python venv
-# with the 
+# proper context, for example to obtain a Nix environment containing the proper Python version,
+# create a python venv with the current Python environment.
 #
 #     make nix-venv-build
 #
@@ -80,7 +82,7 @@ $(VENV):
 	@echo; echo "*** Building $@ VirtualEnv..."
 	@rm -rf $@ && $(PYTHON) -m venv $(VENV_OPTS) $@ && sed -i -e '1s:^:. $$HOME/.bashrc\n:' $@/bin/activate \
 	    && source $@/bin/activate \
-	    && make install
+	    && make install-dev
 
 print-%:
 	@echo $* = $($*)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .pytest_cache
 
 test:
-	pytest
+	pytest -vv --capture=no
 
 style_check:
 	isort --check-only shamir_mnemonic/ *.py

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,15 @@ Install the [Poetry](https://python-poetry.org/) tool, checkout
     $ poetry install
     $ poetry shell
 
+Alternatively, install [Nix](https://nixos.org/download/), and (assuming you have GNU `make` available), run:
+
+.. code-block:: console
+
+    $ make nix-venv-test
+
+to install a Python environment, create a Python `venv`, enter it and run the `make test` target.  To enter
+the `venv` in an interactive shell, run `make nix-venv`.
+
 CLI usage
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,18 @@ You can specify a custom scheme. For example, to create three groups, with 2-of-
 
 Use :code:`shamir --help` or :code:`shamir create --help` to see all available options.
 
+To expand an existing group 3 to include 10 mnemonics, use:
+
+.. code-block:: console
+
+    $ shamir expand --change 3 10
+
+Enter mnemonics sufficient to recover the master secret, including all of the group(s) you desire to
+:code:`--change`.  However, you may elect to replace a missing group with a new single-Share group
+(if you don't specify :code:`--strict`).
+
+Use :code:`shamir --help` or :code:`shamir expand --help` to see all available options.
+
 If you want to run the CLI from a local checkout without installing, use the following
 command:
 

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,28 @@ open, and calculations are most likely trivially vulnerable to side-channel atta
 The purpose of this code is to verify correctness of other implementations. **It should
 not be used for handling sensitive secrets**.
 
+Extendable encrypted master secrets
+-----------------------------------
+
+When you SLIP-39 encode a master secret with a password, you can always recover the original secret
+with the same password.  You of course get a **different** secret (ie. a different wallet) with a
+different password; this is by design: you can (for example) have a master password for your true
+wallet containing your funds, and a "decoy" password for a valid wallet that contains funds to
+satisfy an attacker.  Or, you may simply derive multiple wallets for different purposes with
+different passwords.
+
+The mnemonics are by default "extendable", meaning that you can re-encode the same master secret
+again (with different SLIP-39 group specs), and get the same decrypted secret back with the original
+password, and the **same** wallets with your other passwords.
+
+If desired, you can produce **--no-extendable** encrypted master secrets (which used to be the
+SLIP-39 standard), which always recover the original secret with the original password -- but
+produce **different** secrets for all other passwords.  This only causes surprises when you want to
+re-encrypt the same master secret again: you can't re-obtain the **other** passwords' wallets using
+the newly encoded mnemonics!
+
+To reduce surprises, SLIP-39 now produces **--extendable** encrypted master secrets by default.
+
 Installation
 ------------
 
@@ -94,6 +116,12 @@ You can specify a custom scheme. For example, to create three groups, with 2-of-
     $ shamir create custom --group-threshold 3 --group 2 3 --group 2 5 --group 4 5
 
 Use :code:`shamir --help` or :code:`shamir create --help` to see all available options.
+
+CLI usage: expand an existing mnemonic group
+--------------------------------------------
+
+If you wish to increase the number of mnemonics in an existing multi-mnemonic group, you can now do
+this.  All existing mnemonics remain valid.
 
 To expand an existing group 3 to include 10 mnemonics, use:
 

--- a/default.nix
+++ b/default.nix
@@ -5,67 +5,67 @@ with pkgs;
 let
 in
 {
-  py313 = stdenv.mkDerivation rec {
-    name = "python313-with-pytest";
+  py314 = stdenv.mkDerivation rec {
+    name = "python314-with-poetry";
 
     buildInputs = [
       cacert
       git
       gnumake
       openssh
-      python313Full
+      python314
+      poetry
+    ];
+  };
+
+  py313 = stdenv.mkDerivation rec {
+    name = "python313-with-poetry";
+
+    buildInputs = [
+      cacert
+      git
+      gnumake
+      openssh
+      python313
       poetry
     ];
   };
 
   py312 = stdenv.mkDerivation rec {
-    name = "python312-with-pytest";
+    name = "python312-with-poetry";
 
     buildInputs = [
       cacert
       git
       gnumake
       openssh
-      python312Full
+      python312
       poetry
     ];
   };
  
   py311 = stdenv.mkDerivation rec {
-    name = "python311-with-pytest";
+    name = "python311-with-poetry";
 
     buildInputs = [
       cacert
       git
       gnumake
       openssh
-      python311Full
+      python311
       poetry
     ];
   };
 
   py310 = stdenv.mkDerivation rec {
-    name = "python310-with-pytest";
+    name = "python310-with-poetry";
 
     buildInputs = [
       cacert
       git
       gnumake
       openssh
-      python310Full
-      poetry
-    ];
-  };
-
-  py39 = stdenv.mkDerivation rec {
-    name = "python39-with-pytest";
-
-    buildInputs = [
-      cacert
-      git
-      gnumake
-      openssh
-      python39Full
+      python310
       poetry
     ];
   };

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,72 @@
+{ pkgs ? import ./nixpkgs.nix {} }:
+
+with pkgs;
+
+let
+in
+{
+  py313 = stdenv.mkDerivation rec {
+    name = "python313-with-pytest";
+
+    buildInputs = [
+      cacert
+      git
+      gnumake
+      openssh
+      python313Full
+      poetry
+    ];
+  };
+
+  py312 = stdenv.mkDerivation rec {
+    name = "python312-with-pytest";
+
+    buildInputs = [
+      cacert
+      git
+      gnumake
+      openssh
+      python312Full
+      poetry
+    ];
+  };
+ 
+  py311 = stdenv.mkDerivation rec {
+    name = "python311-with-pytest";
+
+    buildInputs = [
+      cacert
+      git
+      gnumake
+      openssh
+      python311Full
+      poetry
+    ];
+  };
+
+  py310 = stdenv.mkDerivation rec {
+    name = "python310-with-pytest";
+
+    buildInputs = [
+      cacert
+      git
+      gnumake
+      openssh
+      python310Full
+      poetry
+    ];
+  };
+
+  py39 = stdenv.mkDerivation rec {
+    name = "python39-with-pytest";
+
+    buildInputs = [
+      cacert
+      git
+      gnumake
+      openssh
+      python39Full
+      poetry
+    ];
+  };
+}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,4 @@
+import (fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/25.05.tar.gz";
+  sha256 = "1915r28xc4znrh2vf4rrjnxldw2imysz819gzhk9qlrkqanmfsxd";
+})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shamir-mnemonic"
-version = "0.3.1"
+version = "0.3.2"
 description = "SLIP-39 Shamir Mnemonics"
 authors = ["Trezor <info@trezor.io>"]
 license = "MIT"
@@ -20,6 +20,7 @@ pytest = "*"
 black = ">=20"
 flake8 = "*"
 isort = "^5"
+deepset = "*"
 
 [tool.poetry.extras]
 cli = ["click"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ cli = ["click"]
 [tool.poetry.scripts]
 shamir = "shamir_mnemonic.cli:cli"
 
+[tool.black]
+target-version = ['py36']
+
+[tool.isort]
+profile = "black"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ click = { version = ">=7,<9", optional = true }
 [tool.poetry.group.dev.dependencies]
 bip32utils = "^0.3.post4"
 pytest = "*"
+pytest-mypy = { version = "*", python = ">=3.9" }
 black = ">=20"
 flake8 = "*"
 isort = "^5"
@@ -33,6 +34,18 @@ target-version = ['py36']
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_unreachable = true
+strict_equality = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ click = { version = ">=7,<9", optional = true }
 bip32utils = "^0.3.post4"
 pytest = "*"
 black = ">=20"
+flake8 = "*"
 isort = "^5"
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ pytest = "*"
 black = ">=20"
 flake8 = "*"
 isort = "^5"
-deepset = "*"
+deepset = "^1"
 
 [tool.poetry.extras]
 cli = ["click"]

--- a/shamir_mnemonic/__init__.py
+++ b/shamir_mnemonic/__init__.py
@@ -6,6 +6,7 @@ from .shamir import (
     combine_mnemonics,
     decode_mnemonics,
     generate_mnemonics,
+    group_ems_mnemonics,
     recover_ems,
     split_ems,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "combine_mnemonics",
     "decode_mnemonics",
     "generate_mnemonics",
+    "group_ems_mnemonics",
     "split_ems",
     "recover_ems",
     "EncryptedMasterSecret",

--- a/shamir_mnemonic/cli.py
+++ b/shamir_mnemonic/cli.py
@@ -280,7 +280,7 @@ def expand(passphrase_prompt: bool, expand: Iterable[Tuple[int, Optional[int]]],
     )
     for group,mnems in sorted(expanded.items()):
         if group in expand:
-            click.echo(f"Group {group} (expanded to {expand[group]}:" )
+            click.echo(f"Group {group} (expanded to {expand[group] or 'default'}):" )
         else:
             click.echo(f"Group {group}:" )
         for mn in mnems:

--- a/shamir_mnemonic/cli.py
+++ b/shamir_mnemonic/cli.py
@@ -1,6 +1,6 @@
 import secrets
 import sys
-from typing import Sequence, Tuple
+from typing import Iterable, Optional, Sequence, Tuple
 
 try:
     import click
@@ -12,7 +12,7 @@ except ImportError:
     sys.exit(1)
 
 from .recovery import RecoveryState
-from .shamir import generate_mnemonics
+from .shamir import generate_mnemonics, group_ems_mnemonics
 from .share import Share
 from .utils import MnemonicError
 
@@ -168,11 +168,14 @@ def error(s: str) -> None:
     "-p", "--passphrase-prompt", is_flag=True, help="Use passphrase after recovering"
 )
 def recover(passphrase_prompt: bool) -> None:
-    recovery_state = RecoveryState()
+    recovery(passphrase_prompt)
+
+
+def recovery(passphrase_prompt: bool) -> None:
 
     def print_group_status(idx: int) -> None:
-        group_size, group_threshold = recovery_state.group_status(idx)
-        group_prefix = style(recovery_state.group_prefix(idx), bold=True)
+        group_size, group_threshold = recovery.state.group_status(idx)
+        group_prefix = style(recovery.state.group_prefix(idx), bold=True)
         bi = style(str(group_size), bold=True)
         if not group_size:
             click.echo(f"{EMPTY} {bi} shares from group {group_prefix}")
@@ -182,27 +185,27 @@ def recover(passphrase_prompt: bool) -> None:
             click.echo(f"{prefix} {bi} of {bt} shares needed from group {group_prefix}")
 
     def print_status() -> None:
-        bn = style(str(recovery_state.groups_complete()), bold=True)
-        assert recovery_state.parameters is not None
-        bt = style(str(recovery_state.parameters.group_threshold), bold=True)
+        bn = style(str(recovery.state.groups_complete()), bold=True)
+        assert recovery.state.parameters is not None
+        bt = style(str(recovery.state.parameters.group_threshold), bold=True)
         click.echo()
-        if recovery_state.parameters.group_count > 1:
+        if recovery.state.parameters.group_count > 1:
             click.echo(f"Completed {bn} of {bt} groups needed:")
-        for i in range(recovery_state.parameters.group_count):
+        for i in range(recovery.state.parameters.group_count):
             print_group_status(i)
 
-    while not recovery_state.is_complete():
+    while not recovery.state.is_complete():
         try:
             mnemonic_str = click.prompt("Enter a recovery share")
             share = Share.from_mnemonic(mnemonic_str)
-            if not recovery_state.matches(share):
+            if not recovery.state.matches(share):
                 error("This mnemonic is not part of the current set. Please try again.")
                 continue
-            if share in recovery_state:
+            if share in recovery.state:
                 error("Share already entered.")
                 continue
 
-            recovery_state.add_share(share)
+            recovery.state.add_share(share)
             print_status()
 
         except click.Abort:
@@ -223,7 +226,7 @@ def recover(passphrase_prompt: bool) -> None:
                 click.echo("Passphrase must be ASCII. Please try again.")
 
     try:
-        master_secret = recovery_state.recover(passphrase_bytes)
+        master_secret = recovery.state.recover(passphrase_bytes)
     except MnemonicError as e:
         error(str(e))
         click.echo("Recovery failed")
@@ -231,6 +234,57 @@ def recover(passphrase_prompt: bool) -> None:
     click.secho("SUCCESS!", fg="green", bold=True)
     click.echo(f"Your master secret is: {master_secret.hex()}")
 
+recovery.state = RecoveryState()
+
+
+@cli.command()
+@click.option(
+    "-p", "--passphrase-prompt", is_flag=True, help="Use passphrase after recovering"
+)
+@click.option(
+    "-c",
+    "--change",
+    "expand",
+    type=(int, int),
+    metavar="G T",
+    multiple=True,
+    help="Expand the T-of-N group G to the desired new T.",
+)
+@click.option(
+    "-s/-S",
+    "--strict/--no-strict",
+    is_flag=True,
+    default=False,
+    help="Be strict to enforce mnemonics and desired group expand validity.",
+)
+@click.option(
+    "-c/-C",
+    "--complete/--no-complete",
+    is_flag=True,
+    default=False,
+    help="Try to use and assign every mnemonic supplied, even if not necessary for recovery.",
+)
+def expand(passphrase_prompt: bool, expand: Iterable[Tuple[int, Optional[int]]], strict: bool, complete: bool) -> None:
+    """Recover and expand a Shamir mnemonic set
+
+    Displays the (possibly expanded) mnemonics recovered.
+    """
+    recovery(passphrase_prompt)
+    mnemonics = set.union(*(sg.shares for sg in recovery.state.groups.values()))
+    expand = dict(expand)
+    (ems,expanded), = group_ems_mnemonics(
+        mnemonics=mnemonics,
+        strict=strict,
+        complete=complete,
+        expand=expand.items(),
+    )
+    for group,mnems in sorted(expanded.items()):
+        if group in expand:
+            click.echo(f"Group {group} (expanded to {expand[group]}:" )
+        else:
+            click.echo(f"Group {group}:" )
+        for mn in mnems:
+            click.echo(f" {mn}" )
 
 if __name__ == "__main__":
     cli()

--- a/shamir_mnemonic/cli.py
+++ b/shamir_mnemonic/cli.py
@@ -234,6 +234,7 @@ def recovery(passphrase_prompt: bool) -> None:
     click.secho("SUCCESS!", fg="green", bold=True)
     click.echo(f"Your master secret is: {master_secret.hex()}")
 
+
 recovery.state = RecoveryState()
 
 
@@ -264,7 +265,12 @@ recovery.state = RecoveryState()
     default=False,
     help="Try to use and assign every mnemonic supplied, even if not necessary for recovery.",
 )
-def expand(passphrase_prompt: bool, expand: Iterable[Tuple[int, Optional[int]]], strict: bool, complete: bool) -> None:
+def expand(
+    passphrase_prompt: bool,
+    expand: Iterable[Tuple[int, Optional[int]]],
+    strict: bool,
+    complete: bool,
+) -> None:
     """Recover and expand a Shamir mnemonic set
 
     Displays the (possibly expanded) mnemonics recovered.
@@ -272,19 +278,20 @@ def expand(passphrase_prompt: bool, expand: Iterable[Tuple[int, Optional[int]]],
     recovery(passphrase_prompt)
     mnemonics = set.union(*(sg.shares for sg in recovery.state.groups.values()))
     expand = dict(expand)
-    (ems,expanded), = group_ems_mnemonics(
+    ((ems, expanded),) = group_ems_mnemonics(
         mnemonics=mnemonics,
         strict=strict,
         complete=complete,
         expand=expand.items(),
     )
-    for group,mnems in sorted(expanded.items()):
+    for group, mnems in sorted(expanded.items()):
         if group in expand:
-            click.echo(f"Group {group} (expanded to {expand[group] or 'default'}):" )
+            click.echo(f"Group {group} (expanded to {expand[group] or 'default'}):")
         else:
-            click.echo(f"Group {group}:" )
+            click.echo(f"Group {group}:")
         for mn in mnems:
-            click.echo(f" {mn}" )
+            click.echo(f" {mn}")
+
 
 if __name__ == "__main__":
     cli()

--- a/shamir_mnemonic/constants.py
+++ b/shamir_mnemonic/constants.py
@@ -3,7 +3,7 @@ from .utils import bits_to_words
 RADIX_BITS = 10
 """The length of the radix in bits."""
 
-RADIX = 2 ** RADIX_BITS
+RADIX = 2**RADIX_BITS
 """The number of words in the wordlist."""
 
 ID_LENGTH_BITS = 15

--- a/shamir_mnemonic/constants.py
+++ b/shamir_mnemonic/constants.py
@@ -3,7 +3,7 @@ from .utils import bits_to_words
 RADIX_BITS = 10
 """The length of the radix in bits."""
 
-RADIX = 2**RADIX_BITS
+RADIX = 2 ** RADIX_BITS
 """The number of words in the wordlist."""
 
 ID_LENGTH_BITS = 15

--- a/shamir_mnemonic/recovery.py
+++ b/shamir_mnemonic/recovery.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from dataclasses import dataclass, field, replace
+from dataclasses import replace
 from typing import Any, Dict, Optional, Tuple
 
 from .constants import GROUP_PREFIX_LENGTH_WORDS

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -416,9 +416,13 @@ def group_ems_mnemonics(
         # supplied.
         while len(possibles) >= distinct.group_threshold:
             ems, rawshares = ems_rawshares()
-            # Remove all {RawShare: ShareGroup} used from possibles, and return as {group#: Sequence[Share]}
+            # Remove all {RawShare: ShareGroup} used from possibles, and return as {group#:
+            # Sequence[Share]} Each group's set's shares are ordered by index, for testing
+            # repeatability and ordering compatibility with other ..._ems functions.
             groups = {
-                rawshare.x: list(possibles[rawshare.x].pop(rawshare).shares)
+                rawshare.x: sorted(
+                    possibles[rawshare.x].pop(rawshare).shares, key=lambda s: s.index
+                )
                 for rawshare in rawshares
             }
             for x in list(possibles):

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -319,7 +319,7 @@ def group_ems_mnemonics(
         try:
             if isinstance(share, str):
                 share = Share.from_mnemonic(share)
-        except Exception as exc:
+        except Exception:
             pass
         else:
             # We will cluster shares by distinct common_parameters (identifier, extendable,
@@ -363,7 +363,7 @@ def group_ems_mnemonics(
                             groupings.member_threshold, shareminimal.to_raw_shares()
                         ),
                     )
-                except:
+                except Exception:
                     pass
                 else:
                     possibles.setdefault(
@@ -404,7 +404,7 @@ def group_ems_mnemonics(
                             _recover_secret(distinct.group_threshold, rawshares),
                         )
                         return ems, rawshares
-                    except:
+                    except Exception:
                         pass
             # No more encrypted master secrets; return the remaining (unused) RawShares
             return None, sum((possibles[gn].keys() for gn in possibles), [])

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -409,7 +409,7 @@ def group_ems_mnemonics(
                     except Exception:
                         pass
             # No more encrypted master secrets; return the remaining (unused) RawShares
-            return None, sum((possibles[gn].keys() for gn in possibles), [])
+            return None, sum((list(possibles[gn]) for gn in possibles), [])
 
         # Yields every encrypted master secret recovered, and the group indices and set of Share
         # mnemonics used to recover it.  This will be a minimal subset of the groups and mnemonics

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -20,6 +20,7 @@
 #
 
 import hmac
+import itertools
 import secrets
 from dataclasses import dataclass
 from typing import (
@@ -34,7 +35,6 @@ from typing import (
     Tuple,
     Union,
 )
-import itertools
 
 from . import cipher
 from .constants import (

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -30,6 +30,7 @@ from typing import (
     Iterator,
     List,
     NamedTuple,
+    Optional,
     Sequence,
     Set,
     Tuple,
@@ -297,6 +298,34 @@ def _recover_secret(threshold: int, shares: Sequence[RawShare]) -> bytes:
     return shared_secret
 
 
+def _recover_base_rawshares(
+    threshold: int, share_count: int, shares: Sequence[RawShare]
+) -> Sequence[RawShare]:
+    """In addition to just the secret and its digest, we can recover all of a group's original
+    RawShares used to produce its group Shares.
+
+    This allows us to regenerate missing Shares, or even expand a group's member Shares while
+    retaining compatibility with the existing Shares.
+
+    """
+    group_secret = _recover_secret(threshold, shares)  # verifies the digest
+    digest_share = _interpolate(shares, DIGEST_INDEX)
+    if threshold < 2 or len(shares) < threshold or share_count < threshold:
+        raise MnemonicError(
+            f"Cannot recover original group RawShares for group threshold {threshold} of {share_count} with {len(shares)} provided"
+        )
+    random_share_count = threshold - 2
+    shares = [RawShare(i, _interpolate(shares, i)) for i in range(random_share_count)]
+    base_shares = shares + [
+        RawShare(SECRET_INDEX, group_secret),
+        RawShare(DIGEST_INDEX, digest_share),
+    ]
+    return shares + [
+        RawShare(i, _interpolate(base_shares, i))
+        for i in range(random_share_count, share_count)
+    ]
+
+
 def locate_ems_rawshares(
     distinct: ShareCommonParameters,
     possibles: Dict[int, Dict[RawShare, ShareGroup]],
@@ -537,12 +566,112 @@ def group_ems_mnemonics(
     mnemonics: Iterable[Union[str, Share]],
     strict: bool = False,  # Fail if any Share is found to be invalid
     complete: bool = False,  # Find all related Shares, Groups instead of minimal
-) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Set[Share]]]]:
+    expand: Optional[
+        Sequence[Tuple[int, [Optional[int]]]]
+    ] = None,  # group numbers, and desired members (or None)
+) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Set[str]]]]:
     """Here we just care about the recovered EMSs and their mnemonics.  Discard details about the specific
     encodings used.  We could yield the same EMS recovered with different sets of Mnemonics.
 
+    May 'expand' a SLIP-39 group to the same or greater number of mnemonic shares originally
+    specified for the group.  For this to be supported, the Encrypted Master Secret and the target
+    group's RawShare must be recoverable in the supplied mnemonics, or it must be a group with a
+    share threshold of 1.  Any existing group may be also be converted into a group with threshold 1
+    in this fashion.  Unless 'script', any group not found to be expandable will be ignored.
+
     """
-    for (ems, _), using in group_ems_rawshares(mnemonics, strict, complete):
+    for (ems, common_params), using in group_ems_rawshares(mnemonics, strict, complete):
+        for group, desired in expand or []:
+            for rg, sg in using.items():
+                if rg.x == group:
+                    # Found the target group in recoverable EMS RawGroups!
+                    grouping = next(iter(sg.shares)).group_parameters()
+                    if desired is None:
+                        desired = grouping.member_threshold
+                    if (
+                        desired < grouping.member_threshold
+                        or grouping.member_threshold == 1
+                    ):
+                        # They want fewer members than current threshold (impossible to do while
+                        # retaining compatibility with existing mnemonics), or threshold == 1.
+                        # We'll handle the special desired=1 case in loop exhaustion.
+                        continue
+                    # Ready to expand!  Recover all the group's (original) RawShares from the
+                    # supplied shares, and then use them to produce any missing Shares.  This is
+                    # (group_threshold - 2) random RawShares at indices [0,group_threshold-2), plus
+                    # the group secret RawShare at index 255 and the digest RawShare at index 254.
+                    shares = {
+                        Share(
+                            ems.identifier,
+                            ems.extendable,
+                            ems.iteration_exponent,
+                            group,
+                            common_params.group_threshold,
+                            common_params.group_count,
+                            member_index,
+                            grouping.member_threshold,
+                            value,
+                        )
+                        for member_index, value in _recover_base_rawshares(
+                            grouping.member_threshold, desired, sg.to_raw_shares()
+                        )
+                    }
+                    if not sg.shares <= shares:
+                        raise MnemonicError(
+                            f"Expanding group {grouping.group_index} to {desired} Shares produced incompatible mnemonics"
+                        )
+                    sg.shares = shares
+                    break
+            else:
+                # Recovered groups exhausted; expanded group not found in recoverable EMS RawShares.
+                # We can only handle desired=1 for an existing group.
+                if desired == 1 and group < common_params.group_count:
+                    # We're able to produce a single Share for *any* group; even one not provided in
+                    # the supplied mnemonic shares, or previously defined as having a threshold
+                    # greater than one!  This allows us to abandon a known-failed multi-mnemonic
+                    # group and replace it with a new single mnemonic (or recover a missing
+                    # threshold 1 group), if we have sufficient *other* groups to recover the
+                    # Encrypted Master Secret.  Here, we have to recover the full sequence of group
+                    # secrets underpinning the EMS's ciphertext.
+                    for group_index, value in _recover_base_rawshares(
+                        common_params.group_threshold,
+                        common_params.group_count,
+                        using.keys(),
+                    ):
+                        if group == group_index:
+                            shares = {
+                                Share(
+                                    ems.identifier,
+                                    ems.extendable,
+                                    ems.iteration_exponent,
+                                    group,
+                                    common_params.group_threshold,
+                                    common_params.group_count,
+                                    0,
+                                    1,
+                                    value,
+                                )
+                            }
+                            rg = RawShare(group, value)
+                            # assert (rg in using) == bool(
+                            #     len(filter(lambda urg: urg.x == group, using))
+                            # ), f"Incompatible group {group} secret {rg!r} recovered, not matching {using.values()!r}"
+                            if rg in using:
+                                sg = using[rg]
+                                if strict and shares != sg.shares:
+                                    # If 'strict', we won't allow you to replace a recovered multi-mnemonic share group with a new single threshold group.
+                                    raise MnemnonicError(
+                                        f"Incompatible group {group} Share {shares!r} produced, not matching {sg.shares!r}"
+                                    )
+                            else:
+                                sg = ShareGroup()
+                                using[rg] = sg
+                            sg.shares = shares
+                elif strict:
+                    raise MnemonicError(
+                        f"Group {group} not recoverable in supplied mnemonics"
+                    )
+        # Yields the EMS and its recovered group(s), possibly expanded or even replaced with a new single-mnemonic group
         yield ems, {rg.x: set(map(str, sg.shares)) for rg, sg in using.items()}
 
 
@@ -750,6 +879,6 @@ def combine_mnemonics(mnemonics: Iterable[str], passphrase: bytes = b"") -> byte
     if not mnemonics:
         raise MnemonicError("The list of mnemonics is empty.")
 
-    groups = decode_mnemonics(mnemonics)
+    groups: Dict[int, ShareGroup] = decode_mnemonics(mnemonics)
     encrypted_master_secret = recover_ems(groups)
     return encrypted_master_secret.decrypt(passphrase)

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -297,8 +297,55 @@ def _recover_secret(threshold: int, shares: Sequence[RawShare]) -> bytes:
     return shared_secret
 
 
+def locate_ems_rawshares(
+    distinct: ShareCommonParameters,
+    possibles: Dict[int, Dict[RawShare, ShareGroup]],
+    complete: bool = False,
+) -> Tuple[EncryptedMasterSecret, Sequence[RawShare]]:
+    """We have a minimal subset of the available groups indices w/ decoded RawShares secrets
+    (any w/ more than 1 consitutent Share has been validated against its digest).  Produce
+    the cartesian product of groups g0, g1, ..., gN.  The possibles: {x: -> {RawGroup:
+    ShareGroup}} gives us a sequence of RawGroup(s) for group index x.
+
+    This would (inefficiently) find all combinations of available mnemonics that could be
+    combined to recover an encrypted master secret -- but, the caller /should/ remove any
+    used RawShares from possibles before re-invoking to find further EncryptedSharedSecrets
+    to avoid re-trying with RawGroups that are already known to be used by another
+    EncryptedMasterSecret.
+
+    Mutates possibles by removing all (or one, if 'complete') used RawShares.  If no
+    EncryptedMasterSecret is found, returns None w/ remaining undecoded RawShares.
+
+    """
+
+    for subgroups in itertools.combinations(
+            sorted(possibles), distinct.group_threshold
+    ):
+        print( f"Drawing RawShares Cartesian Products from subgroups {subgroups} with RawShares numbering {list(len(possibles[gn]) for gn in subgroups)}" )
+        for rawshares in itertools.product(
+            *(possibles[gn].keys() for gn in subgroups)
+        ):
+            print( f"     ? looking for EMS in groups {subgroups} with rawshares {rawshares}" )
+            try:
+                ems = EncryptedMasterSecret(
+                    distinct.identifier,
+                    distinct.extendable,
+                    distinct.iteration_exponent,
+                    _recover_secret(distinct.group_threshold, rawshares),
+                )
+                # These 'rawshares', collected from a cartesian product group_threshold different 
+                #if complete:
+                #    del possibles[subgroups[0]]
+                return ems, rawshares
+            except Exception:
+                pass
+    # No more encrypted master secrets; return None w/ the remaining (unused) RawShares
+    return None, sum((list(possibles[gn]) for gn in possibles), [])
+
 def group_ems_mnemonics(
-    mnemonics: Iterable[Union[str, Share]], strict: bool = False
+    mnemonics: Iterable[Union[str, Share]],
+    strict: bool = False,		# Fail if any Share is found to be invalid
+    complete: bool = False,		# Find all related Shares, Groups instead of minimal
 ) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Sequence[Share]]]]:
     """Attempt to yield a sequence of unique decoded EncryptedMasterSecret, and the dictionary of group
     indices -> set(<Share>) used to recover each SLIP-39 encoded encrypted seed.
@@ -327,112 +374,127 @@ def group_ems_mnemonics(
         try:
             if isinstance(share, str):
                 share = Share.from_mnemonic(share)
+            distinct = share.common_parameters()
+            grouping = share.group_parameters()
         except Exception:
+            # If something is awry with any supplied Mnemonic, ignore it unless 'strict'
             if strict:
                 raise
         else:
-            # We will cluster mnemonic shares by distinct common_parameters, then by
+            # We will cluster mnemonic shares by distinct common_parameters, then grouping by
             # group_parameters.  This allows us to combine shares from original, extendable (or even
             # expanded additional mnemonics for a group_index generated later), and attempt to
             # recover seeds from mixed incompatible SLIP-39 groups.
             common_params.setdefault(
-                # Incompatible SLIP-39 configurations, by:
+                # Incompatible SLIP-39 configuration groups, by:
                 # - identifier
                 # - extendable
                 # - iteration_exponent
                 # - group_threshold
                 # - group_count
-                share.common_parameters(),
+                distinct,
                 {},
             ).setdefault(
                 # Possible compatible mnemonics within a SLIP-39 configuration, by common_parameters plus:
                 # - group_index
                 # - member_threshold
-                share.group_parameters(),
+                grouping,
                 ShareGroup(),
             ).add(
                 share
+            )
+    print(f"Found {len(common_params)} distinct sets of shares")
+    for distinct, groups in common_params.items():
+        print(
+            f"  id: {distinct.identifier}: {distinct.group_threshold} of {distinct.group_count} groups req'd"
+        )
+        for grouping, sharegroup in groups.items():
+            print(
+                f"   group index: {grouping.group_index}: {len(sharegroup.shares)} of {grouping.member_threshold} shares req'd"
             )
 
     # Now that we have isolated the distinct share groups, it's time to see what we can recover.
     # How many different Mnemonic sets are we possibly dealing with?  In addition to identifier, we
     # have group count, extendable, etc.  Allow multiple independent sets of mnemonics.  Our task is
     # to support the user in recovering their master seeds, however many they may have, or however
-    # the mnemonics may have been mixed.
-
-    # Try every minimum viable subset of groups of length group_threshold, and for each group all
-    # minimum viable subsets of provided mnemonics.  We want to support recovery, even if invalid
-    # Mnemonics have been provided for a group, and if incompatible groups (same identifier and
-    # other common parameters but for a different master seed, or mixed groups) were provided.
+    # the mnemonics may have been mixed.  Try every minimum viable subset of groups of length
+    # group_threshold, and for each group all minimum viable subsets of provided mnemonics.  We want
+    # to support recovery, even if invalid Mnemonics have been provided for a group, and if
+    # incompatible groups (same identifier and other common parameters but for a different master
+    # seed, or mixed groups) were provided.
     recovered: Set[EncryptedMasterSecret] = set()
     for distinct, sharegroups in common_params.items():
         # Go through each of the available groups, identifying all available recoverable group
-        # secrets.  Once a subset of mnemonics is used, discard them and see if any other secrets
-        # are recoverable; multiple different (or decoy) SLIP-39 groups w/ the same common
-        # parameters could have been provided.
+        # secrets, and all mnemonics provided that comprise each.  Once a subset of mnemonics is
+        # used, discard one of them and see if the same or any other secrets are recoverable;
+        # multiple different (or decoy) SLIP-39 groups w/ the same common parameters could have been
+        # provided, and/or redundant mnemonics.
         possibles: Dict[int, Dict[RawShare, ShareGroup]] = {}
         for groupings, sharegroup in sharegroups.items():
-            if not sharegroup.is_complete():
-                continue
-            for shareminimal in sharegroup.get_possible_groups():
-                try:
-                    rawshare = RawShare(
-                        groupings.group_index,
-                        _recover_secret(
-                            groupings.member_threshold, shareminimal.to_raw_shares()
-                        ),
+            print(
+                f"working on id: {distinct.identifier}; group {grouping.group_index} w/ {len(sharegroups)} of {grouping.group_threshold} shares req'd"
+            )
+            while sharegroup.is_complete():
+                for shareminimal in sharegroup.get_possible_groups():
+                    print(
+                        f"  trying share indices {', '.join(str(s.index) for s in shareminimal.shares)} (need at least {sharegroup.member_threshold()})"
                     )
-                except Exception:
-                    pass
+                    try:
+                        rawshare = RawShare(
+                            groupings.group_index,
+                            _recover_secret(
+                                groupings.member_threshold, shareminimal.to_raw_shares()
+                            ),
+                        )
+                    except Exception as exc:
+                        print(
+                            f"  - fail share indices {', '.join(str(s.index) for s in shareminimal.shares)}: {exc}"
+                        )
+                        pass
+                    else:
+                        # We found (another?) minimal ShareGroup subset of sharegroup that leads to
+                        # a RawShare Each time, remove one of its consituent mnemonic Shares, and
+                        # continue looking.  This will (eventually) find *all* mnemonic Shares that
+                        # combine to yield each RawShare.  Add these to the developing ShareGroup
+                        # 'group', and then discard one and retry -- maybe more mnemonics...
+                        print(
+                            f"  - FIND share indices {', '.join(str(s.index) for s in shareminimal.shares)}: {rawshare.x}"
+                        )
+                        group = possibles.setdefault(
+                            # by SLIP-39 group indices
+                            rawshare.x,
+                            {},
+                        ).setdefault(
+                            # by recovered group RawShare
+                            rawshare,
+                            shareminimal,
+                        )
+                        # Simplify; remove either one or all Shares found to reconstitute this RawShare
+                        group.shares |= shareminimal.shares
+                        if complete:
+                            sharegroup.shares.remove(next(iter(shareminimal.shares)))
+                        else:
+                            sharegroup.shares -= shareminimal.shares
+                        break
                 else:
-                    possibles.setdefault(
-                        rawshare.x, {}  # by SLIP-39 group indices
-                    ).setdefault(
-                        rawshare, shareminimal  # by recovered group RawShare
+                    # No RawShare ever found in all possible combinations of this grouping!  Give up.
+                    print(
+                        f"  x No RawShare found in group {groupings.group_index} w/ {len(shareminimal.shares)} shares"
                     )
-                    sharegroup.shares -= shareminimal.shares
                     break
 
         # We now have all resolved available group indices x and their decoded group secret from
-        # RawGroup(x,data), and the first set of Mnemonics that resulted in each.  We want to now
-        # recover all combinations of these groups that lead to different SLIP-39 encrypted master
-        # secrets.  Since we can't know which combinations of group secrets could lead to a
-        # successful SLIP-39 decoding, we'll try every minimal combination of group indices
-        # available.
-        def ems_rawshares():
-            """We have a minimal subset of the available groups indices w/ decoded secrets.
-            Produce the cartesian product of groups g0, g1, ..., gN.  The possibles: {x: ->
-            {RawGroup: ShareGroup}} gives us a sequence of RawGroup(s) for group index x.
+        # RawGroup(x,data), and the minimal (or complete) set of Mnemonics that resulted in each.
+        # We want to now recover all combinations of these groups that lead to different SLIP-39
+        # encrypted master secrets.  Since we can't know which combinations of group secrets could
+        # lead to a successful SLIP-39 decoding, we'll try every minimal combination of group
+        # indices available.
 
-            This would (inefficiently) find all combinations of available mnemonics that could be
-            combined to recover an encrypted master secret -- but, the caller should remove
-            the used RawShares from possibles before re-invoking.
-
-            """
-            for subgroups in itertools.combinations(
-                sorted(possibles), distinct.group_threshold
-            ):
-                for rawshares in itertools.product(
-                    *(possibles[gn].keys() for gn in subgroups)
-                ):
-                    try:
-                        ems = EncryptedMasterSecret(
-                            distinct.identifier,
-                            distinct.extendable,
-                            distinct.iteration_exponent,
-                            _recover_secret(distinct.group_threshold, rawshares),
-                        )
-                        return ems, rawshares
-                    except Exception:
-                        pass
-            # No more encrypted master secrets; return the remaining (unused) RawShares
-            return None, sum((list(possibles[gn]) for gn in possibles), [])
-
-        # Yields every encrypted master secret recovered, and the group indices and set of Share
-        # mnemonics used to recover it.  This will be a minimal subset of the groups and mnemonics
-        # supplied.
+        # Yield every encrypted master secret recovered, and the group indices and set of Share
+        # mnemonics used to recover it.  This will be a minimal (or optionally 'complete') subset of
+        # the groups and mnemonics supplied.
         while len(possibles) >= distinct.group_threshold:
-            ems, rawshares = ems_rawshares()
+            ems, rawshares = locate_ems_rawshares(distinct, possibles)
             # Remove all {RawShare: ShareGroup} used from possibles, and return as {group#:
             # Sequence[Share]} Each group's set's shares are ordered by index, for testing
             # repeatability and ordering compatibility with other ..._ems functions.

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -571,7 +571,7 @@ def expand_group(
     using: Dict[RawShare, ShareGroup],
     common_params: ShareCommonParameters,
     group: int,
-    desired: Optional[int] = None,
+    desired: Optional[int] = None,  # 0/None are equivalent
     strict: bool = False,
 ) -> None:
     """If sufficient group secrets are provided, we can recover the full spectrum of original group
@@ -588,7 +588,7 @@ def expand_group(
         if rg.x == group:
             # Found the target group in recoverable EMS RawGroups!
             grouping = next(iter(sg.shares)).group_parameters()
-            if desired is None:
+            if not desired:
                 desired = grouping.member_threshold
             if desired < grouping.member_threshold or grouping.member_threshold == 1:
                 # They want fewer members than current threshold (impossible to do while
@@ -676,7 +676,7 @@ def group_ems_mnemonics(
     mnemonics: Iterable[Union[str, Share]],
     strict: bool = False,  # Fail if any Share is found to be invalid
     complete: bool = False,  # Find all related Shares, Groups instead of minimal
-    expand: Optional[Sequence[Tuple[int, Optional[int]]]] = None,
+    expand: Optional[Iterable[Tuple[int, Optional[int]]]] = None,
 ) -> Generator[Tuple[EncryptedMasterSecret, Dict[int, Set[str]]], None, None]:
     """Here we just care about the recovered EMSs and their mnemonics.  Discard details about the specific
     encodings used.  We could yield the same EMS recovered with different sets of Mnemonics.

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -25,7 +25,9 @@ import secrets
 from dataclasses import dataclass
 from typing import (
     Any,
+    Collection,
     Dict,
+    Generator,
     Iterable,
     Iterator,
     List,
@@ -186,11 +188,11 @@ def _precompute_exp_log() -> Tuple[List[int], List[int]]:
 EXP_TABLE, LOG_TABLE = _precompute_exp_log()
 
 
-def _interpolate(shares: Sequence[RawShare], x: int) -> bytes:
+def _interpolate(shares: Collection[RawShare], x: int) -> bytes:
     """
     Returns f(x) given the Shamir shares (x_1, f(x_1)), ... , (x_k, f(x_k)).
     :param shares: The Shamir shares.
-    :type shares: A list of pairs (x_i, y_i), where x_i is an integer and y_i is an array of
+    :type shares: A collection of pairs (x_i, y_i), where x_i is an integer and y_i is an array of
         bytes representing the evaluations of the polynomials in x_i.
     :param int x: The x coordinate of the result.
     :return: Evaluations of the polynomials in x.
@@ -282,7 +284,7 @@ def _split_secret(
     return shares
 
 
-def _recover_secret(threshold: int, shares: Sequence[RawShare]) -> bytes:
+def _recover_secret(threshold: int, shares: Collection[RawShare]) -> bytes:
     # If the threshold is 1, then the digest of the shared secret is not used.
     if threshold == 1:
         return next(iter(shares)).data
@@ -299,7 +301,7 @@ def _recover_secret(threshold: int, shares: Sequence[RawShare]) -> bytes:
 
 
 def _recover_secret_rawshares(
-    threshold: int, share_count: int, shares: Sequence[RawShare]
+    threshold: int, share_count: int, shares: Collection[RawShare]
 ) -> Sequence[RawShare]:
     """In addition to just the secret and its digest, we can recover all of a secret's original
     RawShares, that were used to produce its derived Shares.  This is the inverse of _split_secret.
@@ -330,7 +332,7 @@ def locate_ems_rawshares(
     distinct: ShareCommonParameters,
     possibles: Dict[int, Dict[RawShare, ShareGroup]],
     complete: bool = False,
-) -> Sequence[Tuple[EncryptedMasterSecret, Dict[RawShare, ShareGroup]]]:
+) -> Generator[Tuple[EncryptedMasterSecret, Dict[RawShare, ShareGroup]], None, None]:
     """We have the available group indices w/ decoded RawShares secrets x(any w/ more than 1
     constitutent Share has been validated against its digest).  Produce the cartesian product of
     groups g0, g1, ..., gN, to see if we can recover any EncryptedMasterSecrets.  The possibles: {x:
@@ -362,9 +364,9 @@ def locate_ems_rawshares(
                 )
                 using: Dict[RawShare, ShareGroup] = {}
                 for rawshare in rawshares:
-                    # always pops at least one, then gets if 'complete'
+                    # always pops at least one
                     if complete and using:
-                        using[rawshare] = possibles[rawshare.x].get(rawshare)
+                        using[rawshare] = possibles[rawshare.x][rawshare]
                     else:
                         using[rawshare] = possibles[rawshare.x].pop(rawshare)
                 yield ems, using
@@ -478,10 +480,12 @@ def group_ems_rawshares(
     mnemonics: Iterable[Union[str, Share]],
     strict: bool = False,  # Fail if any Share is found to be invalid
     complete: bool = False,  # Find all related Shares, Groups instead of minimal
-) -> Sequence[
+) -> Generator[
     Tuple[
         Tuple[EncryptedMasterSecret, ShareCommonParameters], Dict[RawShare, ShareGroup]
-    ]
+    ],
+    None,
+    None,
 ]:
     """Attempt to yield a sequence of uniquely decoded EncryptedMasterSecrets and their SLIP-39
     encoding parameters, and the dictionary of group indices -> set(<Share>) used to recover each
@@ -673,7 +677,7 @@ def group_ems_mnemonics(
     strict: bool = False,  # Fail if any Share is found to be invalid
     complete: bool = False,  # Find all related Shares, Groups instead of minimal
     expand: Optional[Sequence[Tuple[int, Optional[int]]]] = None,
-) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Set[str]]]]:
+) -> Generator[Tuple[EncryptedMasterSecret, Dict[int, Set[str]]], None, None]:
     """Here we just care about the recovered EMSs and their mnemonics.  Discard details about the specific
     encodings used.  We could yield the same EMS recovered with different sets of Mnemonics.
 

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -818,6 +818,7 @@ def generate_mnemonics(
         reconstruct the group secret.
     :param master_secret: The master secret to split.
     :param passphrase: The passphrase used to encrypt the master secret.
+    :param extendable: Re-encoding of the same secret yields deterministic secrets when decrypted with other passwords
     :param int iteration_exponent: The encryption iteration exponent.
     :return: List of groups mnemonics.
     """

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -453,10 +453,7 @@ def group_ems_mnemonics(
                         pass
                     else:
                         # We found (another?) minimal ShareGroup subset of sharegroup that leads to
-                        # a RawShare Each time, remove one of its consituent mnemonic Shares, and
-                        # continue looking.  This will (eventually) find *all* mnemonic Shares that
-                        # combine to yield each RawShare.  Add these to the developing ShareGroup
-                        # 'group', and then discard one and retry -- maybe more mnemonics...
+                        # a RawShare.
                         print(
                             f"  - FIND share indices {', '.join(str(s.index) for s in shareminimal.shares)}: {rawshare.x}"
                         )
@@ -469,12 +466,12 @@ def group_ems_mnemonics(
                             rawshare,
                             shareminimal,
                         )
-                        # Simplify; remove either one or all Shares found to reconstitute this RawShare
+                        # Each time, remove one of its consituent mnemonic Shares, and continue
+                        # looking to ensure 'complete' coverage; this will (eventually) find *all*
+                        # mnemonic Shares that combine to yield each RawShare.
                         group.shares |= shareminimal.shares
-                        if complete:
-                            sharegroup.shares.remove(next(iter(shareminimal.shares)))
-                        else:
-                            sharegroup.shares -= shareminimal.shares
+                        forget = {next(iter(shareminimal.shares))} if complete else shareminimal.shares
+                        sharegroup.shares -= forget
                         break
                 else:
                     # No RawShare ever found in all possible combinations of this grouping!  Give up.
@@ -492,7 +489,9 @@ def group_ems_mnemonics(
 
         # Yield every encrypted master secret recovered, and the group indices and set of Share
         # mnemonics used to recover it.  This will be a minimal (or optionally 'complete') subset of
-        # the groups and mnemonics supplied.
+        # the groups and mnemonics supplied.  Note that we may end up with plenty of extra RawShares
+        # that we cannot decode an EMS from, if an attacker is at work producing false shares; so
+        # break when we're able to locate None.
         while len(possibles) >= distinct.group_threshold:
             ems, rawshares = locate_ems_rawshares(distinct, possibles)
             # Remove all {RawShare: ShareGroup} used from possibles, and return as {group#:

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -593,7 +593,10 @@ def expand_group(
             # Found the target group in recoverable EMS RawGroups!
             grouping = next(iter(sg.shares)).group_parameters()
             if not desired:
-                desired = max(min(grouping.member_threshold * 2, MAX_SHARE_COUNT), *(s.index + 1 for s in sg.shares))
+                desired = max(
+                    min(grouping.member_threshold * 2, MAX_SHARE_COUNT),
+                    *(s.index + 1 for s in sg.shares),
+                )
             if desired < grouping.member_threshold or grouping.member_threshold == 1:
                 # They want fewer members than current threshold (impossible to do while
                 # retaining compatibility with existing mnemonics), or threshold == 1.

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -533,16 +533,13 @@ def group_ems_mnemonics(
     mnemonics: Iterable[Union[str, Share]],
     strict: bool = False,  # Fail if any Share is found to be invalid
     complete: bool = False,  # Find all related Shares, Groups instead of minimal
-) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, List[Share]]]]:
+) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Set[Share]]]]:
     """Here we just care about the recovered EMSs and their mnemonics.  Discard details about the specific
     encodings used.  We could yield the same EMS recovered with different sets of Mnemonics.
 
     """
     for (ems, _), using in group_ems_rawshares(mnemonics, strict, complete):
-        yield ems, {
-            rg.x: list(map(str, sorted(sg.shares, key=lambda s: s.index)))
-            for rg, sg in using.items()
-        }
+        yield ems, {rg.x: set(map(str, sg.shares)) for rg, sg in using.items()}
 
 
 def decode_mnemonics(mnemonics: Iterable[str]) -> Dict[int, ShareGroup]:

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -301,31 +301,29 @@ def locate_ems_rawshares(
     distinct: ShareCommonParameters,
     possibles: Dict[int, Dict[RawShare, ShareGroup]],
     complete: bool = False,
-) -> Tuple[EncryptedMasterSecret, Sequence[RawShare]]:
-    """We have a minimal subset of the available groups indices w/ decoded RawShares secrets
-    (any w/ more than 1 consitutent Share has been validated against its digest).  Produce
-    the cartesian product of groups g0, g1, ..., gN.  The possibles: {x: -> {RawGroup:
-    ShareGroup}} gives us a sequence of RawGroup(s) for group index x.
+) -> Sequence[Tuple[EncryptedMasterSecret, Dict[RawShare, ShareGroup]]]:
+    """We have the available group indices w/ decoded RawShares secrets (any w/ more than 1
+    constitutent Share has been validated against its digest).  Produce the cartesian product of
+    groups g0, g1, ..., gN, to see if we can recover any EncryptedMasterSecrets.  The possibles: {x:
+    -> {RawGroup: ShareGroup}} gives us a sequence of RawGroup(s) for group index x.
 
     This would (inefficiently) find all combinations of available mnemonics that could be
-    combined to recover an encrypted master secret -- but, the caller /should/ remove any
+    combined to recover any EncryptedMasterSecret -- but, the caller /should/ remove one/all
     used RawShares from possibles before re-invoking to find further EncryptedSharedSecrets
     to avoid re-trying with RawGroups that are already known to be used by another
     EncryptedMasterSecret.
 
-    Mutates possibles by removing all (or one, if 'complete') used RawShares.  If no
-    EncryptedMasterSecret is found, returns None w/ remaining undecoded RawShares.
+    Mutates the supplied 'possibles' to remove one/all RawShares: ShareGroup to support desired
+    level of 'complete'.  If the caller re-invokes (instead of just consuming all Combinations and
+    Cartesian Products, which would yield all possible paths to obtaining each EMS), it can optimize
+    the process of locating all available EMSs.
 
     """
 
     for subgroups in itertools.combinations(
-            sorted(possibles), distinct.group_threshold
+        sorted(possibles), distinct.group_threshold
     ):
-        print( f"Drawing RawShares Cartesian Products from subgroups {subgroups} with RawShares numbering {list(len(possibles[gn]) for gn in subgroups)}" )
-        for rawshares in itertools.product(
-            *(possibles[gn].keys() for gn in subgroups)
-        ):
-            print( f"     ? looking for EMS in groups {subgroups} with rawshares {rawshares}" )
+        for rawshares in itertools.product(*(possibles[gn].keys() for gn in subgroups)):
             try:
                 ems = EncryptedMasterSecret(
                     distinct.identifier,
@@ -333,40 +331,22 @@ def locate_ems_rawshares(
                     distinct.iteration_exponent,
                     _recover_secret(distinct.group_threshold, rawshares),
                 )
-                # These 'rawshares', collected from a cartesian product group_threshold different 
-                #if complete:
-                #    del possibles[subgroups[0]]
-                return ems, rawshares
+                using: Dict[RawShare, ShareGroup] = {}
+                for rawshare in rawshares:
+                    if complete and using:
+                        using[rawshare] = possibles[rawshare.x].get(rawshare)
+                    else:
+                        using[rawshare] = possibles[rawshare.x].pop(rawshare)
+                yield ems, using
             except Exception:
                 pass
-    # No more encrypted master secrets; return None w/ the remaining (unused) RawShares
-    return None, sum((list(possibles[gn]) for gn in possibles), [])
 
-def group_ems_mnemonics(
+
+def group_common_mnemonics(
     mnemonics: Iterable[Union[str, Share]],
-    strict: bool = False,		# Fail if any Share is found to be invalid
-    complete: bool = False,		# Find all related Shares, Groups instead of minimal
-) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Sequence[Share]]]]:
-    """Attempt to yield a sequence of unique decoded EncryptedMasterSecret, and the dictionary of group
-    indices -> set(<Share>) used to recover each SLIP-39 encoded encrypted seed.
-
-    This is difficult to do externally, because it requires partially decoding the mnemonics to
-    deduce the group parameters, and then select a subset of the mnemonics to satisfy them.
-
-    Since extra mnemonics (some perhaps with errors) may be supplied, we may need to produce
-    combinations of Shares until we've eliminated the erroneous one(s).  Then, if someone mistakenly
-    collects groups of incompatible mnemonics (for example, with the same identifier and group
-    numbers, but from a different original master secret, or from an attacker supplying decoy
-    mnenonics), we'll supply all cartesion products of all possible combinations of the available
-    compatible shares to aid recovery of the master secret(s).
-
-    Even if groups of mnemonics from multiple SLIP-39 encodings are collected, aid the caller in
-    recovery of any/all of them.
-
-    Ignores invalid Mnemonics and absence of a recovered secret unless strict is specified.
-
-    """
-    # Eliminate any obviously flawed Mnemonics, group by distinct common, then group parameters
+    strict: bool = False,
+) -> Dict[ShareCommonParameters, Dict[ShareGroupParameters, ShareGroup]]:
+    """Eliminate any obviously flawed Mnemonics, group by distinct common, then group parameters."""
     common_params: Dict[
         ShareCommonParameters, Dict[ShareGroupParameters, ShareGroup]
     ] = {}
@@ -403,15 +383,93 @@ def group_ems_mnemonics(
             ).add(
                 share
             )
-    print(f"Found {len(common_params)} distinct sets of shares")
-    for distinct, groups in common_params.items():
-        print(
-            f"  id: {distinct.identifier}: {distinct.group_threshold} of {distinct.group_count} groups req'd"
-        )
-        for grouping, sharegroup in groups.items():
-            print(
-                f"   group index: {grouping.group_index}: {len(sharegroup.shares)} of {grouping.member_threshold} shares req'd"
-            )
+    return common_params
+
+
+def recover_possible_rawshares(
+    distinct: ShareCommonParameters,
+    sharegroups: Dict[ShareGroupParameters, ShareGroup],
+    complete: bool = False,
+) -> Dict[int, Dict[RawShare, ShareGroup]]:
+    """Go through each of the available groups, identifying all available recoverable group secrets,
+    and all mnemonics provided that comprise each.  Once a subset of mnemonics is used, discard one
+    of them and see if the same or any other secrets are recoverable; multiple different (or decoy)
+    SLIP-39 groups w/ the same common parameters could have been provided, and/or redundant
+    mnemonics.
+
+    """
+    possibles: Dict[int, Dict[RawShare, ShareGroup]] = {}
+    for grouping, sharegroup in sharegroups.items():
+        while sharegroup.is_complete():
+            for shareminimal in sharegroup.get_possible_groups():
+                try:
+                    rawshare = RawShare(
+                        grouping.group_index,
+                        _recover_secret(
+                            grouping.member_threshold, shareminimal.to_raw_shares()
+                        ),
+                    )
+                except Exception as exc:
+                    pass
+                else:
+                    # We found (another?) minimal ShareGroup subset of sharegroup that leads to
+                    # a RawShare.
+                    group = possibles.setdefault(
+                        # by SLIP-39 group indices
+                        rawshare.x,
+                        {},
+                    ).setdefault(
+                        # by recovered group RawShare
+                        rawshare,
+                        shareminimal,
+                    )
+                    # Each time, remove one of its consituent mnemonic Shares, and continue
+                    # looking to ensure 'complete' coverage; this will (eventually) find *all*
+                    # mnemonic Shares that combine to yield each RawShare.
+                    group.shares |= shareminimal.shares
+                    forget = (
+                        {next(iter(shareminimal.shares))}
+                        if complete
+                        else shareminimal.shares
+                    )
+                    sharegroup.shares -= forget
+                    break
+            else:
+                # No RawShare ever found in all possible combinations of this grouping!  Give up.
+                break
+    return possibles
+
+
+def group_ems_rawshares(
+    mnemonics: Iterable[Union[str, Share]],
+    strict: bool = False,  # Fail if any Share is found to be invalid
+    complete: bool = False,  # Find all related Shares, Groups instead of minimal
+) -> Sequence[
+    Tuple[
+        Tuple[EncryptedMasterSecret, ShareCommonParameters], Dict[RawShare, ShareGroup]
+    ]
+]:
+    """Attempt to yield a sequence of uniquely decoded EncryptedMasterSecrets and their SLIP-39
+    encoding parameters, and the dictionary of group indices -> set(<Share>) used to recover each
+    SLIP-39 encoded encrypted seed.  Remember, the same EncryptedMasterSecret may have been encoded
+    with muliple different SLIP-39 encodings.
+
+    This is difficult to do externally, because it requires partially decoding the mnemonics to
+    deduce the group parameters, and then select a subset of the mnemonics to satisfy them.
+
+    Since extra mnemonics (some perhaps with errors) may be supplied, we may need to produce
+    combinations of Shares until we've eliminated the erroneous one(s).  Then, if someone mistakenly
+    collects groups of incompatible mnemonics (for example, with the same identifier and group
+    numbers, but from a different original master secret, or from an attacker supplying decoy
+    mnenonics), we'll supply all cartesion products of all possible combinations of the available
+    compatible shares to aid recovery of the master secret(s).
+
+    Even if groups of mnemonics from multiple SLIP-39 encodings are collected, aid the caller in
+    recovery of any/all of them.
+
+    Ignores invalid Mnemonics and absence of a recovered secret unless strict is specified.
+
+    """
 
     # Now that we have isolated the distinct share groups, it's time to see what we can recover.
     # How many different Mnemonic sets are we possibly dealing with?  In addition to identifier, we
@@ -422,63 +480,16 @@ def group_ems_mnemonics(
     # to support recovery, even if invalid Mnemonics have been provided for a group, and if
     # incompatible groups (same identifier and other common parameters but for a different master
     # seed, or mixed groups) were provided.
-    recovered: Set[EncryptedMasterSecret] = set()
-    for distinct, sharegroups in common_params.items():
-        # Go through each of the available groups, identifying all available recoverable group
-        # secrets, and all mnemonics provided that comprise each.  Once a subset of mnemonics is
-        # used, discard one of them and see if the same or any other secrets are recoverable;
-        # multiple different (or decoy) SLIP-39 groups w/ the same common parameters could have been
-        # provided, and/or redundant mnemonics.
-        possibles: Dict[int, Dict[RawShare, ShareGroup]] = {}
-        for groupings, sharegroup in sharegroups.items():
-            print(
-                f"working on id: {distinct.identifier}; group {grouping.group_index} w/ {len(sharegroups)} of {grouping.group_threshold} shares req'd"
-            )
-            while sharegroup.is_complete():
-                for shareminimal in sharegroup.get_possible_groups():
-                    print(
-                        f"  trying share indices {', '.join(str(s.index) for s in shareminimal.shares)} (need at least {sharegroup.member_threshold()})"
-                    )
-                    try:
-                        rawshare = RawShare(
-                            groupings.group_index,
-                            _recover_secret(
-                                groupings.member_threshold, shareminimal.to_raw_shares()
-                            ),
-                        )
-                    except Exception as exc:
-                        print(
-                            f"  - fail share indices {', '.join(str(s.index) for s in shareminimal.shares)}: {exc}"
-                        )
-                        pass
-                    else:
-                        # We found (another?) minimal ShareGroup subset of sharegroup that leads to
-                        # a RawShare.
-                        print(
-                            f"  - FIND share indices {', '.join(str(s.index) for s in shareminimal.shares)}: {rawshare.x}"
-                        )
-                        group = possibles.setdefault(
-                            # by SLIP-39 group indices
-                            rawshare.x,
-                            {},
-                        ).setdefault(
-                            # by recovered group RawShare
-                            rawshare,
-                            shareminimal,
-                        )
-                        # Each time, remove one of its consituent mnemonic Shares, and continue
-                        # looking to ensure 'complete' coverage; this will (eventually) find *all*
-                        # mnemonic Shares that combine to yield each RawShare.
-                        group.shares |= shareminimal.shares
-                        forget = {next(iter(shareminimal.shares))} if complete else shareminimal.shares
-                        sharegroup.shares -= forget
-                        break
-                else:
-                    # No RawShare ever found in all possible combinations of this grouping!  Give up.
-                    print(
-                        f"  x No RawShare found in group {groupings.group_index} w/ {len(shareminimal.shares)} shares"
-                    )
-                    break
+    common_mnemonics: Dict[
+        ShareCommonParameters, Dict[ShareGroupParameters, ShareGroup]
+    ] = group_common_mnemonics(mnemonics, strict)
+    recovered: Dict[
+        Tuple[EncryptedMasterSecret, ShareCommonParameters], Dict[RawShare, ShareGroup]
+    ] = {}
+    for distinct, sharegroups in common_mnemonics.items():
+        possibles: Dict[int, Dict[RawShare, ShareGroup]] = recover_possible_rawshares(
+            distinct, sharegroups, complete
+        )
 
         # We now have all resolved available group indices x and their decoded group secret from
         # RawGroup(x,data), and the minimal (or complete) set of Mnemonics that resulted in each.
@@ -493,25 +504,45 @@ def group_ems_mnemonics(
         # that we cannot decode an EMS from, if an attacker is at work producing false shares; so
         # break when we're able to locate None.
         while len(possibles) >= distinct.group_threshold:
-            ems, rawshares = locate_ems_rawshares(distinct, possibles)
-            # Remove all {RawShare: ShareGroup} used from possibles, and return as {group#:
-            # Sequence[Share]} Each group's set's shares are ordered by index, for testing
-            # repeatability and ordering compatibility with other ..._ems functions.
-            groups = {
-                rawshare.x: sorted(
-                    possibles[rawshare.x].pop(rawshare).shares, key=lambda s: s.index
-                )
-                for rawshare in rawshares
-            }
-            for x in list(possibles):
-                if not possibles[x]:
-                    possibles.pop(x)
-            if ems and ems not in recovered:
-                yield ems, groups
-                recovered.add(ems)
-
+            for ems, using in locate_ems_rawshares(
+                distinct, possibles, complete=complete
+            ):
+                if (ems, distinct) not in recovered:
+                    # If caller doesn't care about collecting 'complete' set of source {RawShare:
+                    # ShareGroup} used to recover the EMS, yield inline, otherwise at end of
+                    if not complete:
+                        yield (ems, distinct), using
+                recovered.setdefault((ems, distinct), {}).update(using)
+                # Always re-locate to optimize recovery for 'complete' w/ mutated 'possibles'.
+                break
+            else:
+                # No EMS found; even though sufficient RawShares available to satisfy the
+                # group_threshold; fake or incompatible
+                break
+        if complete:
+            # If caller wanted 'complete' set of mnemonics, we'll yield at the end of scanning each
+            # unique share encoding.
+            for (ems, encoding), using in recovered.items():
+                if encoding == distinct:
+                    yield (ems, encoding), using
     if strict and not recovered:
         raise MnemonicError("Invalid set of mnemonics; No encoded secret found")
+
+
+def group_ems_mnemonics(
+    mnemonics: Iterable[Union[str, Share]],
+    strict: bool = False,  # Fail if any Share is found to be invalid
+    complete: bool = False,  # Find all related Shares, Groups instead of minimal
+) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, List[Share]]]]:
+    """Here we just care about the recovered EMSs and their mnemonics.  Discard details about the specific
+    encodings used.  We could yield the same EMS recovered with different sets of Mnemonics.
+
+    """
+    for (ems, _), using in group_ems_rawshares(mnemonics, strict, complete):
+        yield ems, {
+            rg.x: list(map(str, sorted(sg.shares, key=lambda s: s.index)))
+            for rg, sg in using.items()
+        }
 
 
 def decode_mnemonics(mnemonics: Iterable[str]) -> Dict[int, ShareGroup]:

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -93,7 +93,7 @@ class ShareGroup:
     def get_minimal_group(self) -> "ShareGroup":
         return next(self.get_possible_groups())
 
-    def get_possible_groups(self) -> "ShareGroup":
+    def get_possible_groups(self) -> Iterator["ShareGroup"]:
         """Return successive member_threshold length groups of indices into the available shares.
         If the shares are all valid, each group of mnemonics would be equivalent and sufficient to
         use in recovery.  But, if any mnemonic(s) are corrupted we need to avoid using them.
@@ -298,17 +298,17 @@ def _recover_secret(threshold: int, shares: Sequence[RawShare]) -> bytes:
     return shared_secret
 
 
-def _recover_base_rawshares(
+def _recover_secret_rawshares(
     threshold: int, share_count: int, shares: Sequence[RawShare]
 ) -> Sequence[RawShare]:
-    """In addition to just the secret and its digest, we can recover all of a group's original
-    RawShares used to produce its group Shares.
+    """In addition to just the secret and its digest, we can recover all of a secret's original
+    RawShares, that were used to produce its derived Shares.  This is the inverse of _split_secret.
 
     This allows us to regenerate missing Shares, or even expand a group's member Shares while
     retaining compatibility with the existing Shares.
 
     """
-    group_secret = _recover_secret(threshold, shares)  # verifies the digest
+    shared_secret = _recover_secret(threshold, shares)  # verifies the digest
     digest_share = _interpolate(shares, DIGEST_INDEX)
     if threshold < 2 or len(shares) < threshold or share_count < threshold:
         raise MnemonicError(
@@ -317,7 +317,7 @@ def _recover_base_rawshares(
     random_share_count = threshold - 2
     shares = [RawShare(i, _interpolate(shares, i)) for i in range(random_share_count)]
     base_shares = shares + [
-        RawShare(SECRET_INDEX, group_secret),
+        RawShare(SECRET_INDEX, shared_secret),
         RawShare(DIGEST_INDEX, digest_share),
     ]
     return shares + [
@@ -331,7 +331,7 @@ def locate_ems_rawshares(
     possibles: Dict[int, Dict[RawShare, ShareGroup]],
     complete: bool = False,
 ) -> Sequence[Tuple[EncryptedMasterSecret, Dict[RawShare, ShareGroup]]]:
-    """We have the available group indices w/ decoded RawShares secrets (any w/ more than 1
+    """We have the available group indices w/ decoded RawShares secrets x(any w/ more than 1
     constitutent Share has been validated against its digest).  Produce the cartesian product of
     groups g0, g1, ..., gN, to see if we can recover any EncryptedMasterSecrets.  The possibles: {x:
     -> {RawGroup: ShareGroup}} gives us a sequence of RawGroup(s) for group index x.
@@ -362,12 +362,13 @@ def locate_ems_rawshares(
                 )
                 using: Dict[RawShare, ShareGroup] = {}
                 for rawshare in rawshares:
+                    # always pops at least one, then gets if 'complete'
                     if complete and using:
                         using[rawshare] = possibles[rawshare.x].get(rawshare)
                     else:
                         using[rawshare] = possibles[rawshare.x].pop(rawshare)
                 yield ems, using
-            except Exception:
+            except MnemonicError:
                 pass
 
 
@@ -444,7 +445,7 @@ def recover_group_rawshares(
                             grouping.member_threshold, shareminimal.to_raw_shares()
                         ),
                     )
-                except Exception as exc:
+                except Exception:
                     pass
                 else:
                     # We found (another?) minimal ShareGroup subset of sharegroup that leads to
@@ -562,13 +563,116 @@ def group_ems_rawshares(
         raise MnemonicError("Invalid set of mnemonics; No encoded secret found")
 
 
+def expand_group(
+    using: Dict[RawShare, ShareGroup],
+    common_params: ShareCommonParameters,
+    group: int,
+    desired: Optional[int] = None,
+    strict: bool = False,
+) -> None:
+    """If sufficient group secrets are provided, we can recover the full spectrum of original group
+    RawShares.  This recovers all base RawShare secrets (including additional entropy), and is
+    sufficient to produce new (or replacement) 1/1 Shares for every group (even replace multi-Share
+    groups with a new single-Share group, if not 'strict').
+
+    For any group with sufficient mnemonics supplied to recover that group, we can also recover all
+    of the originally generated group RawShare secrets (including additional entropy), allowing us
+    to expand the group to include new mnemonics compatible with the existing mnemonics.
+
+    """
+    for rg, sg in using.items():
+        if rg.x == group:
+            # Found the target group in recoverable EMS RawGroups!
+            grouping = next(iter(sg.shares)).group_parameters()
+            if desired is None:
+                desired = grouping.member_threshold
+            if desired < grouping.member_threshold or grouping.member_threshold == 1:
+                # They want fewer members than current threshold (impossible to do while
+                # retaining compatibility with existing mnemonics), or threshold == 1.
+                # We'll handle the special desired=1 case in loop exhaustion.
+                continue
+            if desired > MAX_SHARE_COUNT:
+                raise ValueError(
+                    f"The requested number of shares must not exceed {MAX_SHARE_COUNT}."
+                )
+            # Ready to expand!  Recover all the group's (original) RawShares from the
+            # supplied shares, and then use them to produce any missing Shares.  This is
+            # (group_threshold - 2) random RawShares at indices [0,group_threshold-2), plus
+            # the group secret RawShare at index 255 and the digest RawShare at index 254.
+            shares = {
+                Share(
+                    common_params.identifier,
+                    common_params.extendable,
+                    common_params.iteration_exponent,
+                    group,
+                    common_params.group_threshold,
+                    common_params.group_count,
+                    member_index,
+                    grouping.member_threshold,
+                    value,
+                )
+                for member_index, value in _recover_secret_rawshares(
+                    grouping.member_threshold, desired, sg.to_raw_shares()
+                )
+            }
+            if not sg.shares <= shares:
+                # Expanding a group must never produce incompatible mnemonics!
+                raise MnemonicError(
+                    f"Expanding group {grouping.group_index} to {desired} Shares produced incompatible mnemonics"
+                )
+            sg.shares = shares
+            break
+    else:
+        # Recovered groups exhausted; group not found in recoverable EMS RawShares.  We can satisfy
+        # desired=1 for any group, even replacing a group if not 'strict'.
+        if desired == 1 and group < common_params.group_count:
+            # We're able to produce a single Share for *any* group; even one not provided in
+            # the supplied mnemonic shares, or previously defined as having a threshold
+            # greater than one!  This allows us to abandon a known-failed multi-mnemonic
+            # group and replace it with a new single mnemonic (or recover a missing
+            # threshold 1 group), if we have sufficient *other* groups to recover the
+            # Encrypted Master Secret.  Here, we have to recover the full sequence of group
+            # secrets underpinning the EMS's ciphertext.
+            for group_index, value in _recover_secret_rawshares(
+                common_params.group_threshold,
+                common_params.group_count,
+                using.keys(),
+            ):
+                if group == group_index:
+                    shares = {
+                        Share(
+                            common_params.identifier,
+                            common_params.extendable,
+                            common_params.iteration_exponent,
+                            group,
+                            common_params.group_threshold,
+                            common_params.group_count,
+                            0,
+                            1,
+                            value,
+                        )
+                    }
+                    rg = RawShare(group, value)
+                    sg = using.setdefault(rg, ShareGroup())
+                    if strict and not sg.shares <= shares:
+                        # If 'strict', we won't allow you to replace a multi-mnemonic share group
+                        # with a new single threshold group.
+                        sg_threshold = (
+                            next(iter(sg.shares)).group_parameters().member_threshold
+                        )
+                        raise MnemonicError(
+                            f"Incompatible single-Share group {group} produced for existing {sg_threshold}-Share group"
+                        )
+                    sg.shares = shares
+        elif strict:
+            raise MnemonicError(f"Group {group} not recoverable in supplied mnemonics")
+
+
 def group_ems_mnemonics(
     mnemonics: Iterable[Union[str, Share]],
     strict: bool = False,  # Fail if any Share is found to be invalid
     complete: bool = False,  # Find all related Shares, Groups instead of minimal
-    expand: Optional[
-        Sequence[Tuple[int, [Optional[int]]]]
-    ] = None,  # group numbers, and desired members (or None)
+    expand: Optional[Sequence[Tuple[int, Optional[int]]]] = None,
 ) -> Sequence[Tuple[EncryptedMasterSecret, Dict[int, Set[str]]]]:
     """Here we just care about the recovered EMSs and their mnemonics.  Discard details about the specific
     encodings used.  We could yield the same EMS recovered with different sets of Mnemonics.
@@ -579,99 +683,13 @@ def group_ems_mnemonics(
     share threshold of 1.  Any existing group may be also be converted into a group with threshold 1
     in this fashion.  Unless 'script', any group not found to be expandable will be ignored.
 
+    Yields the EMS and its recovered group(s), possibly expanded or (if not 'strict') even replaced
+    with a new single-mnemonic group.
+
     """
     for (ems, common_params), using in group_ems_rawshares(mnemonics, strict, complete):
         for group, desired in expand or []:
-            for rg, sg in using.items():
-                if rg.x == group:
-                    # Found the target group in recoverable EMS RawGroups!
-                    grouping = next(iter(sg.shares)).group_parameters()
-                    if desired is None:
-                        desired = grouping.member_threshold
-                    if (
-                        desired < grouping.member_threshold
-                        or grouping.member_threshold == 1
-                    ):
-                        # They want fewer members than current threshold (impossible to do while
-                        # retaining compatibility with existing mnemonics), or threshold == 1.
-                        # We'll handle the special desired=1 case in loop exhaustion.
-                        continue
-                    # Ready to expand!  Recover all the group's (original) RawShares from the
-                    # supplied shares, and then use them to produce any missing Shares.  This is
-                    # (group_threshold - 2) random RawShares at indices [0,group_threshold-2), plus
-                    # the group secret RawShare at index 255 and the digest RawShare at index 254.
-                    shares = {
-                        Share(
-                            ems.identifier,
-                            ems.extendable,
-                            ems.iteration_exponent,
-                            group,
-                            common_params.group_threshold,
-                            common_params.group_count,
-                            member_index,
-                            grouping.member_threshold,
-                            value,
-                        )
-                        for member_index, value in _recover_base_rawshares(
-                            grouping.member_threshold, desired, sg.to_raw_shares()
-                        )
-                    }
-                    if not sg.shares <= shares:
-                        raise MnemonicError(
-                            f"Expanding group {grouping.group_index} to {desired} Shares produced incompatible mnemonics"
-                        )
-                    sg.shares = shares
-                    break
-            else:
-                # Recovered groups exhausted; expanded group not found in recoverable EMS RawShares.
-                # We can only handle desired=1 for an existing group.
-                if desired == 1 and group < common_params.group_count:
-                    # We're able to produce a single Share for *any* group; even one not provided in
-                    # the supplied mnemonic shares, or previously defined as having a threshold
-                    # greater than one!  This allows us to abandon a known-failed multi-mnemonic
-                    # group and replace it with a new single mnemonic (or recover a missing
-                    # threshold 1 group), if we have sufficient *other* groups to recover the
-                    # Encrypted Master Secret.  Here, we have to recover the full sequence of group
-                    # secrets underpinning the EMS's ciphertext.
-                    for group_index, value in _recover_base_rawshares(
-                        common_params.group_threshold,
-                        common_params.group_count,
-                        using.keys(),
-                    ):
-                        if group == group_index:
-                            shares = {
-                                Share(
-                                    ems.identifier,
-                                    ems.extendable,
-                                    ems.iteration_exponent,
-                                    group,
-                                    common_params.group_threshold,
-                                    common_params.group_count,
-                                    0,
-                                    1,
-                                    value,
-                                )
-                            }
-                            rg = RawShare(group, value)
-                            # assert (rg in using) == bool(
-                            #     len(filter(lambda urg: urg.x == group, using))
-                            # ), f"Incompatible group {group} secret {rg!r} recovered, not matching {using.values()!r}"
-                            if rg in using:
-                                sg = using[rg]
-                                if strict and shares != sg.shares:
-                                    # If 'strict', we won't allow you to replace a recovered multi-mnemonic share group with a new single threshold group.
-                                    raise MnemnonicError(
-                                        f"Incompatible group {group} Share {shares!r} produced, not matching {sg.shares!r}"
-                                    )
-                            else:
-                                sg = ShareGroup()
-                                using[rg] = sg
-                            sg.shares = shares
-                elif strict:
-                    raise MnemonicError(
-                        f"Group {group} not recoverable in supplied mnemonics"
-                    )
-        # Yields the EMS and its recovered group(s), possibly expanded or even replaced with a new single-mnemonic group
+            expand_group(using, common_params, group, desired, strict)
         yield ems, {rg.x: set(map(str, sg.shares)) for rg, sg in using.items()}
 
 

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -386,12 +386,18 @@ def group_common_mnemonics(
     return common_params
 
 
-def recover_possible_rawshares(
-    distinct: ShareCommonParameters,
+def recover_group_rawshares(
     sharegroups: Dict[ShareGroupParameters, ShareGroup],
     complete: bool = False,
 ) -> Dict[int, Dict[RawShare, ShareGroup]]:
-    """Go through each of the available groups, identifying all available recoverable group secrets,
+    """Recovers all available SLIP-39 group RawShares, optionally collecting the 'complete' set of
+    provided Shares belonging to the ShareGroup used to recover the group's RawShare secret.
+    Ignores invalid, incomplete or otherwise unusable Shares provided.  Produces a dict keyed by all
+    deduced group RawShare x coordinates, to a dict keyed by all recovered RawShares for each group
+    x coordinate, mapped to the ShareGroup of Shares used to recover it.  These RawShares may
+    represent 1 or more SLIP-39 encoded EncryptedMasterSecrets.
+
+    Go through each of the available groups, identifying all available recoverable group secrets,
     and all mnemonics provided that comprise each.  Once a subset of mnemonics is used, discard
     one/all of them and see if the same or any other secrets are recoverable; multiple different (or
     decoy) SLIP-39 groups w/ the same common parameters could have been provided, and/or redundant
@@ -427,12 +433,10 @@ def recover_possible_rawshares(
                     # looking to ensure 'complete' coverage; this will (eventually) find *all*
                     # mnemonic Shares that combine to yield each RawShare.
                     group.shares |= shareminimal.shares
-                    forget = (
-                        {next(iter(shareminimal.shares))}
-                        if complete
-                        else shareminimal.shares
-                    )
-                    sharegroup.shares -= forget
+                    if complete:
+                        sharegroup.shares.remove(next(iter(shareminimal.shares)))
+                    else:
+                        sharegroup.shares -= shareminimal.shares
                     break
             else:
                 # No RawShare ever found in all possible combinations of this grouping!  Give up.
@@ -487,8 +491,8 @@ def group_ems_rawshares(
         Tuple[EncryptedMasterSecret, ShareCommonParameters], Dict[RawShare, ShareGroup]
     ] = {}
     for distinct, sharegroups in common_mnemonics.items():
-        possibles: Dict[int, Dict[RawShare, ShareGroup]] = recover_possible_rawshares(
-            distinct, sharegroups, complete
+        possibles: Dict[int, Dict[RawShare, ShareGroup]] = recover_group_rawshares(
+            sharegroups, complete
         )
 
         # We now have all resolved available group indices x and their decoded group secret from

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -583,13 +583,17 @@ def expand_group(
     of the originally generated group RawShare secrets (including additional entropy), allowing us
     to expand the group to include new mnemonics compatible with the existing mnemonics.
 
+    It isn't possible to know how many shares in addition to the minimum member_threshold were
+    originally produced; if desired is 0/None, we'll try to pick a sensible default; twice the
+    member_threshold for multi-Share groups (or the greatest share index actually provided).
+
     """
     for rg, sg in using.items():
         if rg.x == group:
             # Found the target group in recoverable EMS RawGroups!
             grouping = next(iter(sg.shares)).group_parameters()
             if not desired:
-                desired = grouping.member_threshold
+                desired = max(min(grouping.member_threshold * 2, MAX_SHARE_COUNT), *(s.index + 1 for s in sg.shares))
             if desired < grouping.member_threshold or grouping.member_threshold == 1:
                 # They want fewer members than current threshold (impossible to do while
                 # retaining compatibility with existing mnemonics), or threshold == 1.

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -93,6 +93,11 @@ class ShareGroup:
         return next(self.get_possible_groups())
 
     def get_possible_groups(self) -> "ShareGroup":
+        """Return successive member_threshold length groups of indices into the available shares.
+        If the shares are all valid, each group of mnemonics would be equivalent and sufficient to
+        use in recovery.  But, if any mnemonic(s) are corrupted we need to avoid using them.
+
+        """
         if not self.is_complete():
             raise MnemonicError(
                 f"Incomplete group of mnemonics; {len(self.shares)} provided of {self.member_threshold()} required."
@@ -302,10 +307,11 @@ def group_ems_mnemonics(
     deduce the group parameters, and then select a subset of the mnemonics to satisfy them.
 
     Since extra mnemonics (some perhaps with errors) may be supplied, we may need to produce
-    combinations until we've eliminated the erroneous one(s).  Then, if someone mistakenly collects
-    groups of incompatible mnemonics (for example, with the same identifier and group numbers, but
-    from a different original master secret, or from an attacker supplying decoy mnenonics), we'll
-    supply all possible combinations of the available groups to aid recovery of the master secret.
+    combinations of Shares until we've eliminated the erroneous one(s).  Then, if someone mistakenly
+    collects groups of incompatible mnemonics (for example, with the same identifier and group
+    numbers, but from a different original master secret, or from an attacker supplying decoy
+    mnenonics), we'll supply all cartesion products of all possible combinations of the available
+    compatible shares to aid recovery of the master secret(s).
 
     Even if groups of mnemonics from multiple SLIP-39 encodings are collected, aid the caller in
     recovery of any/all of them.
@@ -325,21 +331,32 @@ def group_ems_mnemonics(
             if strict:
                 raise
         else:
-            # We will cluster shares by distinct common_parameters (identifier, extendable,
-            # iteration_exponent, group_threshold, group_count), then by group_parameters.  This allows
-            # us to combine shares from original or extended mnemonics generated later, and attempt to
-            # recover mixed incompatible SLIP-39 groups.
+            # We will cluster mnemonic shares by distinct common_parameters, then by
+            # group_parameters.  This allows us to combine shares from original, extendable (or even
+            # expanded additional mnemonics for a group_index generated later), and attempt to
+            # recover seeds from mixed incompatible SLIP-39 groups.
             common_params.setdefault(
-                share.common_parameters(), {}  # incompatible SLIP-39 configurations
+                # Incompatible SLIP-39 configurations, by:
+                # - identifier
+                # - extendable
+                # - iteration_exponent
+                # - group_threshold
+                # - group_count
+                share.common_parameters(),
+                {},
             ).setdefault(
-                share.group_parameters(), ShareGroup()  # compatible mnemonics
+                # Possible compatible mnemonics within a SLIP-39 configuration, by common_parameters plus:
+                # - group_index
+                # - member_threshold
+                share.group_parameters(),
+                ShareGroup(),
             ).add(
-                share  # Cannot fail
+                share
             )
 
     # Now that we have isolated the distinct share groups, it's time to see what we can recover.
     # How many different Mnemonic sets are we possibly dealing with?  In addition to identifier, we
-    # have group count, extended, etc.  Allow multiple independent sets of mnemonics.  Our task is
+    # have group count, extendable, etc.  Allow multiple independent sets of mnemonics.  Our task is
     # to support the user in recovering their master seeds, however many they may have, or however
     # the mnemonics may have been mixed.
 
@@ -387,7 +404,7 @@ def group_ems_mnemonics(
             Produce the cartesian product of groups g0, g1, ..., gN.  The possibles: {x: ->
             {RawGroup: ShareGroup}} gives us a sequence of RawGroup(s) for group index x.
 
-            This would (inefficiently) find all combinations of available mnemonics the could be
+            This would (inefficiently) find all combinations of available mnemonics that could be
             combined to recover an encrypted master secret -- but, the caller should remove
             the used RawShares from possibles before re-invoking.
 

--- a/shamir_mnemonic/shamir.py
+++ b/shamir_mnemonic/shamir.py
@@ -392,9 +392,9 @@ def recover_possible_rawshares(
     complete: bool = False,
 ) -> Dict[int, Dict[RawShare, ShareGroup]]:
     """Go through each of the available groups, identifying all available recoverable group secrets,
-    and all mnemonics provided that comprise each.  Once a subset of mnemonics is used, discard one
-    of them and see if the same or any other secrets are recoverable; multiple different (or decoy)
-    SLIP-39 groups w/ the same common parameters could have been provided, and/or redundant
+    and all mnemonics provided that comprise each.  Once a subset of mnemonics is used, discard
+    one/all of them and see if the same or any other secrets are recoverable; multiple different (or
+    decoy) SLIP-39 groups w/ the same common parameters could have been provided, and/or redundant
     mnemonics.
 
     """
@@ -471,11 +471,11 @@ def group_ems_rawshares(
 
     """
 
-    # Now that we have isolated the distinct share groups, it's time to see what we can recover.
-    # How many different Mnemonic sets are we possibly dealing with?  In addition to identifier, we
-    # have group count, extendable, etc.  Allow multiple independent sets of mnemonics.  Our task is
-    # to support the user in recovering their master seeds, however many they may have, or however
-    # the mnemonics may have been mixed.  Try every minimum viable subset of groups of length
+    # Once we have isolated the distinct share groups, it's time to see what we can recover.  How
+    # many different Mnemonic sets are we possibly dealing with?  In addition to identifier, we have
+    # group count, extendable, etc.  Allow multiple independent sets of mnemonics.  Our task is to
+    # support the user in recovering their master seeds, however many they may have, or however the
+    # mnemonics may have been mixed.  Try every minimum viable subset of groups of length
     # group_threshold, and for each group all minimum viable subsets of provided mnemonics.  We want
     # to support recovery, even if invalid Mnemonics have been provided for a group, and if
     # incompatible groups (same identifier and other common parameters but for a different master

--- a/shamir_mnemonic/share.py
+++ b/shamir_mnemonic/share.py
@@ -136,6 +136,9 @@ class Share:
         """Convert share data to a share mnemonic."""
         return " ".join(self.words())
 
+    def __str__(self) -> str:
+        return self.mnemonic()
+
     @classmethod
     def from_mnemonic(cls, mnemonic: str) -> "Share":
         """Convert a share mnemonic to share data."""

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import ./nixpkgs.nix {} }:
+
+let
+  targets = import ./default.nix {
+    inherit pkgs;
+  };
+  targeted = builtins.getEnv "TARGET";
+  selected = targeted + pkgs.lib.optionalString (targeted == "") "py313";
+in
+
+with pkgs;
+
+mkShell {
+  buildInputs = lib.getAttrFromPath [ selected "buildInputs" ] targets;
+
+  shellHook = ''
+    echo "Welcome to the Python ${selected} environment!"
+  '';
+}

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -284,9 +284,10 @@ def test_group_ems_mnemonics(monkeypatch):
             ),
         ],
     ]
+    # Confirm that the extended Mnemonics are a superset of the original Mnemonics
     assert mnemonics_nonext_b[0] == mnemonics_nonext_a[0]
-    assert mnemonics_nonext_b[1][:3] == mnemonics_nonext_a[1]
-    assert mnemonics_nonext_b[2][:5] == mnemonics_nonext_a[2]
+    assert mnemonics_nonext_b[1] > mnemonics_nonext_a[1]
+    assert mnemonics_nonext_b[2] > mnemonics_nonext_a[2]
 
     mnemonics_extend_a = shamir.split_ems(
         2,
@@ -387,8 +388,8 @@ def test_group_ems_mnemonics(monkeypatch):
         ],
     ]
     assert mnemonics_extend_b[0] == mnemonics_extend_a[0]
-    assert mnemonics_extend_b[1][:3] == mnemonics_extend_a[1]
-    assert mnemonics_extend_b[2][:5] == mnemonics_extend_a[2]
+    assert mnemonics_extend_b[1] > mnemonics_extend_a[1]
+    assert mnemonics_extend_b[2] > mnemonics_extend_a[2]
 
     # Note that both SLIP-39 Mnemonics are "extendable", regardless of the value of the extendable
     # option when created.  So long as the caller only alters the number of shares in a group (and
@@ -397,9 +398,13 @@ def test_group_ems_mnemonics(monkeypatch):
 
     # We'll expect exactly one recovery for this set of mnemonic shares.  Note that we're recovering
     # a "non-extendable" EncryptedMasterSecret here, using output from two split_ems calls with
-    # different group member counts, but identical thresholds:
+    # different group member counts, but identical thresholds.  Here we use the ..._nonext_a's group 0, but
+    # only the new Mnemonics from ..._nonext_b:
     ems, groups = next(
-        shamir.group_ems_mnemonics(mnemonics_nonext_a[0] + mnemonics_nonext_b[1][:-2])
+        shamir.group_ems_mnemonics(
+            mnemonics_nonext_a[0]
+            + list(set(mnemonics_nonext_b[1]) - set(mnemonics_nonext_a[1]))
+        )
     )
     # print( f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}" )
     assert ems.decrypt(b"TREZOR") == MS
@@ -411,10 +416,10 @@ def test_group_ems_mnemonics(monkeypatch):
         ],
         1: [
             Share.from_mnemonic(
-                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material"
+                "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
             ),
             Share.from_mnemonic(
-                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that"
+                "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
             ),
         ],
     }

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -1,5 +1,6 @@
 import json
 import secrets
+import pytest
 from itertools import combinations
 from random import shuffle
 
@@ -7,7 +8,7 @@ import pytest
 from bip32utils import BIP32Key
 
 import shamir_mnemonic as shamir
-from shamir_mnemonic import MnemonicError
+from shamir_mnemonic import MnemonicError, Share
 
 MS = b"ABCDEFGHIJKLMNOP"
 
@@ -181,3 +182,155 @@ def test_recover_ems():
     encrypted_master_secret = shamir.recover_ems(groups)
     recovered = encrypted_master_secret.decrypt(b"TREZOR")
     assert recovered == MS
+
+
+def test_group_ems_mnemonics(monkeypatch):
+    monkeypatch.setattr( shamir.shamir, 'RANDOM_BYTES', lambda n: n * b'\0' )
+
+    def stringify( lst ):
+        return [ stringify(x) if isinstance(x, list) else str(x) for x in lst ]
+
+    mnemonics_nonext_a = shamir.split_ems(
+        2, [(1,1), (2,3), (3,5)],
+        shamir.EncryptedMasterSecret.from_master_secret(
+            MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
+        )
+    )
+    #print( json.dumps( mnemonics_nonext_a, indent=4, default=str ))
+    assert mnemonics_nonext_a == [
+        [
+            Share.from_mnemonic( "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting" )
+        ],
+        [
+            Share.from_mnemonic( "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that" ),
+            Share.from_mnemonic( "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught" ),
+            Share.from_mnemonic( "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material" )
+        ],
+        [
+            Share.from_mnemonic( "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack" ),
+            Share.from_mnemonic( "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange" ),
+            Share.from_mnemonic( "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material" ),
+            Share.from_mnemonic( "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake" ),
+            Share.from_mnemonic( "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack" )
+        ]
+    ]
+    mnemonics_nonext_b = shamir.split_ems(
+        2, [(1,1), (2,5), (3,7)],  # <-- increase group member count
+        shamir.EncryptedMasterSecret.from_master_secret(
+            MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
+        )
+    )
+    #print( json.dumps( mnemonics_nonext_b, indent=4, default=str ))
+    assert mnemonics_nonext_b == [
+        [
+            Share.from_mnemonic( "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting" )
+        ],
+        [
+            Share.from_mnemonic( "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that" ),
+            Share.from_mnemonic( "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught" ),
+            Share.from_mnemonic( "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material" ),
+            Share.from_mnemonic( "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal" ),
+            Share.from_mnemonic( "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush" )
+        ],
+        [
+            Share.from_mnemonic( "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack" ),
+            Share.from_mnemonic( "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange" ),
+            Share.from_mnemonic( "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material" ),
+            Share.from_mnemonic( "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake" ),
+            Share.from_mnemonic( "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack" ),
+            Share.from_mnemonic( "academic acid ceramic mortgage ancient beard duration wolf beam smirk ultimate helpful amuse rapids item election plastic library voting orange" ),
+            Share.from_mnemonic( "academic acid ceramic nervous devote force galaxy veteran much priority losing injury frost swimming vegan learn dress ruler formal material" )
+        ]
+    ]
+    assert mnemonics_nonext_b[0] == mnemonics_nonext_a[0]
+    assert mnemonics_nonext_b[1][:3] == mnemonics_nonext_a[1]
+    assert mnemonics_nonext_b[2][:5] == mnemonics_nonext_a[2]
+
+    mnemonics_extend_a = shamir.split_ems(
+        2, [(1,1), (2,3), (3,5)],
+        shamir.EncryptedMasterSecret.from_master_secret(
+            MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
+        )
+    )
+    #print( json.dumps( mnemonics_extend_a, indent=4, default=str ))
+    assert mnemonics_extend_a == [
+        [
+            Share.from_mnemonic( "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult" )
+        ],
+        [
+            Share.from_mnemonic( "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music" ),
+            Share.from_mnemonic( "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon" ),
+            Share.from_mnemonic( "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf" )
+        ],
+        [
+            Share.from_mnemonic( "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence" ),
+            Share.from_mnemonic( "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal" ),
+            Share.from_mnemonic( "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority" ),
+            Share.from_mnemonic( "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar" ),
+            Share.from_mnemonic( "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal" )
+        ]
+    ]
+    mnemonics_extend_b = shamir.split_ems(
+        2, [(1,1), (2,5), (3,7)],  # <-- increase group member count
+        shamir.EncryptedMasterSecret.from_master_secret(
+            MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
+        )
+    )
+    #print( json.dumps( mnemonics_extend_b, indent=4, default=str ))
+    assert mnemonics_extend_b == [
+        [
+            Share.from_mnemonic( "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult" )
+        ],
+        [
+            Share.from_mnemonic( "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music" ),
+            Share.from_mnemonic( "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon" ),
+            Share.from_mnemonic( "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf" ),
+            Share.from_mnemonic( "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy" ),
+            Share.from_mnemonic( "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy" )
+        ],
+        [
+            Share.from_mnemonic( "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence" ),
+            Share.from_mnemonic( "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal" ),
+            Share.from_mnemonic( "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority" ),
+            Share.from_mnemonic( "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar" ),
+            Share.from_mnemonic( "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal" ),
+            Share.from_mnemonic( "academic agency ceramic mortgage desert imply tenant package dream syndrome paid diet clothes cluster scout average depend fused cubic express" ),
+            Share.from_mnemonic( "academic agency ceramic nervous calcium item graduate critical license darkness spine total fiber numb starting eraser justice that deny clothes" )
+        ]
+    ]
+    assert mnemonics_extend_b[0] == mnemonics_extend_a[0]
+    assert mnemonics_extend_b[1][:3] == mnemonics_extend_a[1]
+    assert mnemonics_extend_b[2][:5] == mnemonics_extend_a[2]
+
+    # Note that both SLIP-39 Mnemonics are "extendable", regardless of the value of the extendable
+    # option when created.  So long as the caller only alters the number of shares in a group (and
+    # not the group count or threshold, or the group member threshold required), you can create
+    # additional group members usable to recover the original EncryptedMasterSecret.
+
+    # We'll expect exactly one recovery for this set of mnemonic shares.  Note that we're recovering
+    # a "non-extendable" EncryptedMasterSecret here, using output from two split_ems calls with
+    # different group member counts, but identical thresholds:
+    ems, groups = next( shamir.group_ems_mnemonics( mnemonics_nonext_a[0] + mnemonics_nonext_b[1][:-2] ))
+    #print( f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}" )
+    assert ems.decrypt( b"TREZOR" ) == MS
+    assert groups == {
+        0: [
+            Share.from_mnemonic( "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting" )
+        ],
+        1: [
+            Share.from_mnemonic( "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material" ),
+            Share.from_mnemonic( "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that" )
+        ]
+    }
+
+    # Here, we'll recover both unique EncryptedMasterSecret values with unique common_parameters
+    # from the pool of all available mnemonics.  This is the super-power of group_ems_mnemonics; it
+    # will process arbitrary pools of Mnemonics, identify the unique common_parameters, and then
+    # iterate over all combinations and cartesion products of available share groups to try to
+    # recover any SLIP-39 encoded EncryptedMasterSecret values available.  It will ignore any
+    # invalid, redundant or incomplete mnemonics.
+    recovered = []
+    for ems,groups in shamir.group_ems_mnemonics( sum( mnemonics_nonext_a + mnemonics_nonext_b + mnemonics_extend_a + mnemonics_extend_b, [] )):
+        recovered.append(ems)
+    assert len(recovered) == 2
+    assert all( ems.decrypt( b"TREZOR" ) == MS for ems in recovered )

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -185,118 +185,207 @@ def test_recover_ems():
 
 
 def test_group_ems_mnemonics(monkeypatch):
-    monkeypatch.setattr( shamir.shamir, 'RANDOM_BYTES', lambda n: n * b'\0' )
-
-    def stringify( lst ):
-        return [ stringify(x) if isinstance(x, list) else str(x) for x in lst ]
+    monkeypatch.setattr(shamir.shamir, "RANDOM_BYTES", lambda n: n * b"\0")
 
     mnemonics_nonext_a = shamir.split_ems(
-        2, [(1,1), (2,3), (3,5)],
+        2,
+        [(1, 1), (2, 3), (3, 5)],
         shamir.EncryptedMasterSecret.from_master_secret(
             MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
-        )
+        ),
     )
-    #print( json.dumps( mnemonics_nonext_a, indent=4, default=str ))
+    # print( json.dumps( mnemonics_nonext_a, indent=4, default=str ))
     assert mnemonics_nonext_a == [
         [
-            Share.from_mnemonic( "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting" )
+            Share.from_mnemonic(
+                "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
+            )
         ],
         [
-            Share.from_mnemonic( "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that" ),
-            Share.from_mnemonic( "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught" ),
-            Share.from_mnemonic( "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material" )
+            Share.from_mnemonic(
+                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material"
+            ),
         ],
         [
-            Share.from_mnemonic( "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack" ),
-            Share.from_mnemonic( "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange" ),
-            Share.from_mnemonic( "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material" ),
-            Share.from_mnemonic( "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake" ),
-            Share.from_mnemonic( "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack" )
-        ]
+            Share.from_mnemonic(
+                "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack"
+            ),
+        ],
     ]
     mnemonics_nonext_b = shamir.split_ems(
-        2, [(1,1), (2,5), (3,7)],  # <-- increase group member count
+        2,
+        [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
         shamir.EncryptedMasterSecret.from_master_secret(
             MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
-        )
+        ),
     )
-    #print( json.dumps( mnemonics_nonext_b, indent=4, default=str ))
+    # print( json.dumps( mnemonics_nonext_b, indent=4, default=str ))
     assert mnemonics_nonext_b == [
         [
-            Share.from_mnemonic( "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting" )
+            Share.from_mnemonic(
+                "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
+            )
         ],
         [
-            Share.from_mnemonic( "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that" ),
-            Share.from_mnemonic( "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught" ),
-            Share.from_mnemonic( "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material" ),
-            Share.from_mnemonic( "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal" ),
-            Share.from_mnemonic( "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush" )
+            Share.from_mnemonic(
+                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
+            ),
         ],
         [
-            Share.from_mnemonic( "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack" ),
-            Share.from_mnemonic( "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange" ),
-            Share.from_mnemonic( "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material" ),
-            Share.from_mnemonic( "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake" ),
-            Share.from_mnemonic( "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack" ),
-            Share.from_mnemonic( "academic acid ceramic mortgage ancient beard duration wolf beam smirk ultimate helpful amuse rapids item election plastic library voting orange" ),
-            Share.from_mnemonic( "academic acid ceramic nervous devote force galaxy veteran much priority losing injury frost swimming vegan learn dress ruler formal material" )
-        ]
+            Share.from_mnemonic(
+                "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic mortgage ancient beard duration wolf beam smirk ultimate helpful amuse rapids item election plastic library voting orange"
+            ),
+            Share.from_mnemonic(
+                "academic acid ceramic nervous devote force galaxy veteran much priority losing injury frost swimming vegan learn dress ruler formal material"
+            ),
+        ],
     ]
     assert mnemonics_nonext_b[0] == mnemonics_nonext_a[0]
     assert mnemonics_nonext_b[1][:3] == mnemonics_nonext_a[1]
     assert mnemonics_nonext_b[2][:5] == mnemonics_nonext_a[2]
 
     mnemonics_extend_a = shamir.split_ems(
-        2, [(1,1), (2,3), (3,5)],
+        2,
+        [(1, 1), (2, 3), (3, 5)],
         shamir.EncryptedMasterSecret.from_master_secret(
             MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
-        )
+        ),
     )
-    #print( json.dumps( mnemonics_extend_a, indent=4, default=str ))
+    # print( json.dumps( mnemonics_extend_a, indent=4, default=str ))
     assert mnemonics_extend_a == [
         [
-            Share.from_mnemonic( "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult" )
+            Share.from_mnemonic(
+                "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
+            )
         ],
         [
-            Share.from_mnemonic( "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music" ),
-            Share.from_mnemonic( "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon" ),
-            Share.from_mnemonic( "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf" )
+            Share.from_mnemonic(
+                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music"
+            ),
+            Share.from_mnemonic(
+                "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon"
+            ),
+            Share.from_mnemonic(
+                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf"
+            ),
         ],
         [
-            Share.from_mnemonic( "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence" ),
-            Share.from_mnemonic( "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal" ),
-            Share.from_mnemonic( "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority" ),
-            Share.from_mnemonic( "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar" ),
-            Share.from_mnemonic( "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal" )
-        ]
+            Share.from_mnemonic(
+                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal"
+            ),
+        ],
     ]
     mnemonics_extend_b = shamir.split_ems(
-        2, [(1,1), (2,5), (3,7)],  # <-- increase group member count
+        2,
+        [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
         shamir.EncryptedMasterSecret.from_master_secret(
             MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
-        )
+        ),
     )
-    #print( json.dumps( mnemonics_extend_b, indent=4, default=str ))
+    # print( json.dumps( mnemonics_extend_b, indent=4, default=str ))
     assert mnemonics_extend_b == [
         [
-            Share.from_mnemonic( "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult" )
+            Share.from_mnemonic(
+                "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
+            )
         ],
         [
-            Share.from_mnemonic( "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music" ),
-            Share.from_mnemonic( "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon" ),
-            Share.from_mnemonic( "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf" ),
-            Share.from_mnemonic( "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy" ),
-            Share.from_mnemonic( "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy" )
+            Share.from_mnemonic(
+                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music"
+            ),
+            Share.from_mnemonic(
+                "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon"
+            ),
+            Share.from_mnemonic(
+                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf"
+            ),
+            Share.from_mnemonic(
+                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy"
+            ),
+            Share.from_mnemonic(
+                "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
+            ),
         ],
         [
-            Share.from_mnemonic( "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence" ),
-            Share.from_mnemonic( "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal" ),
-            Share.from_mnemonic( "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority" ),
-            Share.from_mnemonic( "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar" ),
-            Share.from_mnemonic( "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal" ),
-            Share.from_mnemonic( "academic agency ceramic mortgage desert imply tenant package dream syndrome paid diet clothes cluster scout average depend fused cubic express" ),
-            Share.from_mnemonic( "academic agency ceramic nervous calcium item graduate critical license darkness spine total fiber numb starting eraser justice that deny clothes" )
-        ]
+            Share.from_mnemonic(
+                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic mortgage desert imply tenant package dream syndrome paid diet clothes cluster scout average depend fused cubic express"
+            ),
+            Share.from_mnemonic(
+                "academic agency ceramic nervous calcium item graduate critical license darkness spine total fiber numb starting eraser justice that deny clothes"
+            ),
+        ],
     ]
     assert mnemonics_extend_b[0] == mnemonics_extend_a[0]
     assert mnemonics_extend_b[1][:3] == mnemonics_extend_a[1]
@@ -310,17 +399,25 @@ def test_group_ems_mnemonics(monkeypatch):
     # We'll expect exactly one recovery for this set of mnemonic shares.  Note that we're recovering
     # a "non-extendable" EncryptedMasterSecret here, using output from two split_ems calls with
     # different group member counts, but identical thresholds:
-    ems, groups = next( shamir.group_ems_mnemonics( mnemonics_nonext_a[0] + mnemonics_nonext_b[1][:-2] ))
-    #print( f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}" )
-    assert ems.decrypt( b"TREZOR" ) == MS
+    ems, groups = next(
+        shamir.group_ems_mnemonics(mnemonics_nonext_a[0] + mnemonics_nonext_b[1][:-2])
+    )
+    # print( f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}" )
+    assert ems.decrypt(b"TREZOR") == MS
     assert groups == {
         0: [
-            Share.from_mnemonic( "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting" )
+            Share.from_mnemonic(
+                "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
+            )
         ],
         1: [
-            Share.from_mnemonic( "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material" ),
-            Share.from_mnemonic( "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that" )
-        ]
+            Share.from_mnemonic(
+                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material"
+            ),
+            Share.from_mnemonic(
+                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that"
+            ),
+        ],
     }
 
     # Here, we'll recover both unique EncryptedMasterSecret values with unique common_parameters
@@ -330,7 +427,15 @@ def test_group_ems_mnemonics(monkeypatch):
     # recover any SLIP-39 encoded EncryptedMasterSecret values available.  It will ignore any
     # invalid, redundant or incomplete mnemonics.
     recovered = []
-    for ems,groups in shamir.group_ems_mnemonics( sum( mnemonics_nonext_a + mnemonics_nonext_b + mnemonics_extend_a + mnemonics_extend_b, [] )):
+    for ems, groups in shamir.group_ems_mnemonics(
+        sum(
+            mnemonics_nonext_a
+            + mnemonics_nonext_b
+            + mnemonics_extend_a
+            + mnemonics_extend_b,
+            [],
+        )
+    ):
         recovered.append(ems)
     assert len(recovered) == 2
-    assert all( ems.decrypt( b"TREZOR" ) == MS for ems in recovered )
+    assert all(ems.decrypt(b"TREZOR") == MS for ems in recovered)

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -1,6 +1,5 @@
 import json
 import secrets
-import pytest
 from itertools import combinations
 from random import shuffle
 

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -499,3 +499,93 @@ def test_group_ems_mnemonics(monkeypatch):
             ],
         },
     }
+
+
+    # Let's test some groups of mnemonics from different seeds, but the same parameters.  Again, we
+    # are suppressing entropy, so the only thing that will differ is the encryption of the seed; all
+    # other EMS parameters will be identical, and (of course) the underlying seed is identical.
+    ems_MS_extend_DIFFER = shamir.EncryptedMasterSecret.from_master_secret(
+        MS, b"DIFFER", identifier=0, extendable=True, iteration_exponent=1
+    )
+    assert ems_MS_extend != ems_MS_extend_DIFFER
+    assert ems_MS_extend.decrypt(b"TREZOR") == ems_MS_extend_DIFFER.decrypt(b"DIFFER")== MS
+
+    # Produce SLIP-39 mnemonics for the alternatively encrypted (but identically parameterized) EMS
+    mnemonics_extend_b_DIFFER = shamir.split_ems(
+        2,
+        [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
+        ems_MS_extend_DIFFER,
+    )
+    print( "MS w/ TREZOR:", json.dumps( mnemonics_extend_b, indent=4, default=str ))
+    print( "MS w/ DIFFER:", json.dumps( mnemonics_extend_b_DIFFER, indent=4, default=str ))
+
+    import random
+    class ShareCorrupt( Share ):
+        def corrupt( self, bits=1 ) -> "Share":
+            value_array = bytearray(self.value)
+            pairs = set()
+            while len(pairs) < bits:
+                pairs.add( (random.randint(0, len(value_array)-1), random.randint(0, 7)) )
+            for byte,bit in pairs:
+                value_array[byte] ^= (1 << bit)
+            return Share(
+                self.identifier,
+                self.extendable,
+                self.iteration_exponent,
+                self.group_index,
+                self.group_threshold,
+                self.group_count,
+                self.index,
+                self.member_threshold,
+                bytes(value_array)
+            )
+
+    def corrupt( share, bits=1 ):
+        if isinstance(share, Share):
+            share = share.mnemonic()
+        return (
+            ShareCorrupt
+            .from_mnemonic( share )
+            .corrupt( bits )
+            .mnemonic()
+        )
+
+    print( corrupt(  "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy" ))
+    assert corrupt( "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy", bits=0 ) \
+        == "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
+    assert corrupt( "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy" ) \
+        != "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
+
+
+    # Now, attempt to recover.  Should regain both EMSs, even though all Shares have identical
+    # parameters!!  Remember -- it is a /feature/ of SLIP-39 that an incorrect decryption key
+    # results in a "valid" decrypted seed (just a seed that doesn't match the original).  So, see if
+    # any decryption with the possible passwords correctly recovers the original seed...
+    recovered = {}
+    shares = (
+        sum(
+            mnemonics_extend_b
+            + mnemonics_extend_b_DIFFER,
+            [],
+        )
+        + list( map( corrupt, sum(
+            mnemonics_extend_b,
+            [],
+        )))
+    )
+    print( "Mnemonics w/ TREZOR, DIFFER and corrupt sets:", json.dumps( shares, indent=4, default=str ))
+    for ems, groups in shamir.group_ems_mnemonics(
+        shares,
+        complete = False,
+    ):
+        assert ems not in recovered
+        recovered[ems] = groups
+
+    assert len(recovered) == 2
+    print(
+        json.dumps(
+            {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+        )
+    )
+    assert all( any( map( lambda p: ems.decrypt( p ) == MS, (b"TREZOR", b"DIFFER") )) for ems in recovered), \
+        "Failed to recover original seed w/ any valid password"

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -674,6 +674,35 @@ def test_group_ems_mnemonics(monkeypatch):
     assert deepset(recovered) < expected
 
 
+ones = b"\xff" * 16
+ones_mnemonics = {
+    # First 1/1
+    0: {
+        "olympic guilt acrobat romp dining inform withdraw brave lips quarter bulge thorn best wildlife alive yelp home security lilac eclipse",
+    },
+    # Second 1/1
+    1: {
+        "olympic guilt beard romp apart preach various garden always mayor solution acid quantity domestic slush zero fatigue disaster fluff romp",
+    },
+    # Fam 2/4
+    2: {
+        "olympic guilt ceramic roster agency evidence beard emerald triumph crystal flip threaten yield slow dwarf mason together kidney center memory",
+        "olympic guilt ceramic scared dream shrimp upgrade flip scroll cylinder evaluate acquire evening idle omit learn impulse custody estimate blanket",
+        "olympic guilt ceramic shadow density false spark hesitate desert counter born omit smoking preach beyond dilemma aunt switch revenue peanut",
+        "olympic guilt ceramic sister angel speak deliver idea brave crazy aide isolate grasp birthday pulse domestic object market squeeze dismiss",
+    },
+    # Frens 3/6
+    3: {
+        "olympic guilt decision round animal velvet bedroom species railroad energy findings general laden estate music ordinary tolerate duration photo laden",
+        "olympic guilt decision scatter agency speak rapids quantity slice mustang fragment universe tackle screw wrist install moisture ticket founder display",
+        "olympic guilt decision shaft auction various lyrics amazing peasant withdraw editor swing makeup review analysis physics capacity marathon beaver divorce",
+        "olympic guilt decision skin acrobat spelling dance guest sugar crunch envy fancy cradle declare gasoline exceed hairy flash ugly language",
+        "olympic guilt decision snake costume teaspoon aluminum deadline steady cricket subject bedroom acrobat elbow numb material scatter dramatic capture advance",
+        "olympic guilt decision spider coastal round promise expect paper width spelling ounce party smart username grin provide tracks theater engage",
+    },
+}
+
+
 def test_group_expand():
     """Confirm that we can recover an EMS from a groups of SLIP-39 mnemonics, and "expand" those
     groups to include more mnemonics compatible with the existing ones.
@@ -681,33 +710,6 @@ def test_group_expand():
     We'll use a pre-generated 2 of 1/1, 1/1, 2/4 and 3/6 grouping.
 
     """
-    ones = b"\xff" * 16
-    ones_mnemonics = {
-        # First 1/1
-        0: {
-            "olympic guilt acrobat romp dining inform withdraw brave lips quarter bulge thorn best wildlife alive yelp home security lilac eclipse",
-        },
-        # Second 1/1
-        1: {
-            "olympic guilt beard romp apart preach various garden always mayor solution acid quantity domestic slush zero fatigue disaster fluff romp",
-        },
-        # Fam 2/4
-        2: {
-            "olympic guilt ceramic roster agency evidence beard emerald triumph crystal flip threaten yield slow dwarf mason together kidney center memory",
-            "olympic guilt ceramic scared dream shrimp upgrade flip scroll cylinder evaluate acquire evening idle omit learn impulse custody estimate blanket",
-            "olympic guilt ceramic shadow density false spark hesitate desert counter born omit smoking preach beyond dilemma aunt switch revenue peanut",
-            "olympic guilt ceramic sister angel speak deliver idea brave crazy aide isolate grasp birthday pulse domestic object market squeeze dismiss",
-        },
-        # Frens 3/6
-        3: {
-            "olympic guilt decision round animal velvet bedroom species railroad energy findings general laden estate music ordinary tolerate duration photo laden",
-            "olympic guilt decision scatter agency speak rapids quantity slice mustang fragment universe tackle screw wrist install moisture ticket founder display",
-            "olympic guilt decision shaft auction various lyrics amazing peasant withdraw editor swing makeup review analysis physics capacity marathon beaver divorce",
-            "olympic guilt decision skin acrobat spelling dance guest sugar crunch envy fancy cradle declare gasoline exceed hairy flash ugly language",
-            "olympic guilt decision snake costume teaspoon aluminum deadline steady cricket subject bedroom acrobat elbow numb material scatter dramatic capture advance",
-            "olympic guilt decision spider coastal round promise expect paper width spelling ounce party smart username grin provide tracks theater engage",
-        },
-    }
 
     # We can recover the original "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong" =~=
     # 0xffffffffffffffffffffffffffffffff seed and all of the supplied mnemonics are valid and
@@ -718,7 +720,8 @@ def test_group_expand():
     assert ems.decrypt(b"") == ones
     assert recovered == ones_mnemonics
 
-    # Now, lets only supply the Fam and Frens, and ensure we can get back the 1/1 shares
+    # Now, lets only supply the Fam and Frens, and ensure we can get back the 1/1 shares.  Since
+    # they contain no additional entropy, they will always match the original 1/1 shares.
     ((ems, recovered),) = shamir.group_ems_mnemonics(
         set.union(ones_mnemonics[2], ones_mnemonics[3])
     )
@@ -750,7 +753,7 @@ def test_group_expand():
         "olympic guilt beard romp apart preach various garden always mayor solution acid quantity domestic slush zero fatigue disaster fluff romp",
     }
 
-    # OK, we've recovered 2 1/1 groups.  Now, lets see if we can expand an existing threshold/count
+    # OK, we've recovered 2 1/1 groups.  Now, let's see if we can expand an existing threshold/count
     # group to increase the group's member count.  Let's increase Frens from a 3/6 to a larger 3/10
     ((ems, recovered),) = shamir.group_ems_mnemonics(
         set.union(ones_mnemonics[0], ones_mnemonics[3]),
@@ -761,8 +764,39 @@ def test_group_expand():
     assert (
         deepset(ones_mnemonics[3]) < recovered[3]
     )  # In fact, original group 3 is now a subset!
-    print(
-        json.dumps(
-            {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+    # print(
+    #     json.dumps(
+    #         {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+    #     )
+    # )
+
+
+def test_group_expand_failures():
+    # Too many mnemonics are disallowed
+    with pytest.raises(ValueError):
+        ((ems, recovered),) = shamir.group_ems_mnemonics(
+            set.union(ones_mnemonics[0], ones_mnemonics[3]),
+            expand=[(3, 17)],
         )
+    # Replacing a multi-Share group is disallowed if 'strict'
+    with pytest.raises(MnemonicError):
+        ((ems, recovered),) = shamir.group_ems_mnemonics(
+            set.union(ones_mnemonics[0], ones_mnemonics[3]),
+            expand=[(3, 1)],
+            strict=True,
+        )
+    # ... but allowed if not 'strict'
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(ones_mnemonics[0], ones_mnemonics[3]),
+        expand=[(3, 1)],
     )
+    # And the resultant single-mnemonic group is usable to recover the Encrypted Master Secret
+    # print(
+    #     json.dumps(
+    #         {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+    #     )
+    # )
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(recovered[0], recovered[3]),
+    )
+    assert ems.decrypt(b"") == ones

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -508,7 +508,7 @@ def test_group_ems_mnemonics(monkeypatch):
         assert ems not in recovered
         recovered[ems] = groups
     assert len(recovered) == 2
-    assert deepset(recovered) <= expected
+    assert deepset(recovered) < expected
 
     # Let's test some groups of mnemonics from different seeds, but the same parameters.  Again, we
     # are suppressing entropy, so the only thing that will differ is the encryption of the seed; all
@@ -671,4 +671,4 @@ def test_group_ems_mnemonics(monkeypatch):
         recovered[ems] = groups
 
     assert len(recovered) == 2
-    assert deepset(recovered) <= expected
+    assert deepset(recovered) < expected

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -3,6 +3,7 @@ import random
 import secrets
 from itertools import combinations
 from random import shuffle
+from typing import Union
 
 import pytest
 from bip32utils import BIP32Key
@@ -531,9 +532,9 @@ def test_group_ems_mnemonics(monkeypatch):
     )
 
     class ShareCorrupt(Share):
-        def corrupt(self, bits=1) -> "Share":
+        def corrupt(self, bits: int = 1) -> "Share":
             value_array = bytearray(self.value)
-            pairs = set()
+            pairs: set[tuple[int, int]] = set()
             while len(pairs) < bits:
                 pairs.add(
                     (random.randint(0, len(value_array) - 1), random.randint(0, 7))
@@ -552,7 +553,7 @@ def test_group_ems_mnemonics(monkeypatch):
                 bytes(value_array),
             )
 
-    def corrupt(share, bits=1):
+    def corrupt(share: Union[Share, str], bits: int = 1) -> str:
         if isinstance(share, Share):
             share = share.mnemonic()
         return ShareCorrupt.from_mnemonic(share).corrupt(bits).mnemonic()

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -186,12 +186,13 @@ def test_recover_ems():
 def test_group_ems_mnemonics(monkeypatch):
     monkeypatch.setattr(shamir.shamir, "RANDOM_BYTES", lambda n: n * b"\0")
 
+    ems_MS_nonext = shamir.EncryptedMasterSecret.from_master_secret(
+        MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
+    )
     mnemonics_nonext_a = shamir.split_ems(
         2,
         [(1, 1), (2, 3), (3, 5)],
-        shamir.EncryptedMasterSecret.from_master_secret(
-            MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
-        ),
+        ems_MS_nonext,
     )
     # print( json.dumps( mnemonics_nonext_a, indent=4, default=str ))
     assert mnemonics_nonext_a == [
@@ -229,12 +230,11 @@ def test_group_ems_mnemonics(monkeypatch):
             ),
         ],
     ]
+
     mnemonics_nonext_b = shamir.split_ems(
         2,
         [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
-        shamir.EncryptedMasterSecret.from_master_secret(
-            MS, b"TREZOR", identifier=0, extendable=False, iteration_exponent=1
-        ),
+        ems_MS_nonext,
     )
     # print( json.dumps( mnemonics_nonext_b, indent=4, default=str ))
     assert mnemonics_nonext_b == [
@@ -289,12 +289,14 @@ def test_group_ems_mnemonics(monkeypatch):
     assert mnemonics_nonext_b[1] > mnemonics_nonext_a[1]
     assert mnemonics_nonext_b[2] > mnemonics_nonext_a[2]
 
+    # Now, generate an identically encrypted EMS (since we have eliminated all entropy), only differing in 'extenable'.
+    ems_MS_extend = shamir.EncryptedMasterSecret.from_master_secret(
+        MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
+    )
     mnemonics_extend_a = shamir.split_ems(
         2,
         [(1, 1), (2, 3), (3, 5)],
-        shamir.EncryptedMasterSecret.from_master_secret(
-            MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
-        ),
+        ems_MS_extend,
     )
     # print( json.dumps( mnemonics_extend_a, indent=4, default=str ))
     assert mnemonics_extend_a == [
@@ -335,9 +337,7 @@ def test_group_ems_mnemonics(monkeypatch):
     mnemonics_extend_b = shamir.split_ems(
         2,
         [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
-        shamir.EncryptedMasterSecret.from_master_secret(
-            MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
-        ),
+        ems_MS_extend,
     )
     # print( json.dumps( mnemonics_extend_b, indent=4, default=str ))
     assert mnemonics_extend_b == [
@@ -400,29 +400,28 @@ def test_group_ems_mnemonics(monkeypatch):
     # a "non-extendable" EncryptedMasterSecret here, using output from two split_ems calls with
     # different group member counts, but identical thresholds.  Here we use the ..._nonext_a's group 0, but
     # only the new Mnemonics from ..._nonext_b:
-    ems, groups = next(
-        shamir.group_ems_mnemonics(
-            mnemonics_nonext_a[0]
-            + list(set(mnemonics_nonext_b[1]) - set(mnemonics_nonext_a[1]))
-        )
-    )
-    # print( f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}" )
-    assert ems.decrypt(b"TREZOR") == MS
-    assert groups == {
-        0: [
-            Share.from_mnemonic(
-                "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
-            )
-        ],
-        1: [
-            Share.from_mnemonic(
-                "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
-            ),
-            Share.from_mnemonic(
-                "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
-            ),
-        ],
-    }
+    for ems, groups in shamir.group_ems_mnemonics(
+        mnemonics_nonext_a[0]
+        + list(set(mnemonics_nonext_b[1]) - set(mnemonics_nonext_a[1]))
+    ):
+        print(f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}")
+        assert ems.decrypt(b"TREZOR") == MS
+
+        assert groups == {
+            0: [
+                Share.from_mnemonic(
+                    "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
+                )
+            ],
+            1: [
+                Share.from_mnemonic(
+                    "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
+                ),
+                Share.from_mnemonic(
+                    "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
+                ),
+            ],
+        }
 
     # Here, we'll recover both unique EncryptedMasterSecret values with unique common_parameters
     # from the pool of all available mnemonics.  This is the super-power of group_ems_mnemonics; it
@@ -430,7 +429,7 @@ def test_group_ems_mnemonics(monkeypatch):
     # iterate over all combinations and cartesion products of available share groups to try to
     # recover any SLIP-39 encoded EncryptedMasterSecret values available.  It will ignore any
     # invalid, redundant or incomplete mnemonics.
-    recovered = []
+    recovered = {}
     for ems, groups in shamir.group_ems_mnemonics(
         sum(
             mnemonics_nonext_a
@@ -438,8 +437,65 @@ def test_group_ems_mnemonics(monkeypatch):
             + mnemonics_extend_a
             + mnemonics_extend_b,
             [],
-        )
+        ),
+        complete = True,
     ):
-        recovered.append(ems)
+        assert ems not in recovered
+        recovered[ems] = groups
     assert len(recovered) == 2
-    assert all(ems.decrypt(b"TREZOR") == MS for ems in recovered)
+    assert all(ems.decrypt(b"TREZOR") == MS for ems, _ in recovered.items())
+    print(
+        json.dumps(
+            {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+        )
+    )
+    assert recovered == {
+        ems_MS_nonext: {
+            0: [
+                Share.from_mnemonic(
+                    "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
+                )
+            ],
+            1: [
+                Share.from_mnemonic(
+                    "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that"
+                ),
+                Share.from_mnemonic(
+                    "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught"
+                ),
+                Share.from_mnemonic(
+                    "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material"
+                ),
+                Share.from_mnemonic(
+                    "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
+                ),
+                Share.from_mnemonic(
+                    "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
+                ),
+            ],
+        },
+        ems_MS_extend: {
+            0: [
+                Share.from_mnemonic(
+                    "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
+                )
+            ],
+            1: [
+                Share.from_mnemonic(
+                    "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music"
+                ),
+                Share.from_mnemonic(
+                    "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon"
+                ),
+                Share.from_mnemonic(
+                    "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf"
+                ),
+                Share.from_mnemonic(
+                    "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy"
+                ),
+                Share.from_mnemonic(
+                    "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
+                ),
+            ],
+        },
+    }

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -404,22 +404,16 @@ def test_group_ems_mnemonics(monkeypatch):
         mnemonics_nonext_a[0]
         + list(set(mnemonics_nonext_b[1]) - set(mnemonics_nonext_a[1]))
     ):
-        print(f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}")
+        # print(f"Recovered {ems} using: {json.dumps( groups, indent=4, default=str )}")
         assert ems.decrypt(b"TREZOR") == MS
 
         assert groups == {
             0: [
-                Share.from_mnemonic(
-                    "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
-                )
+                "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
             ],
             1: [
-                Share.from_mnemonic(
-                    "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
-                ),
-                Share.from_mnemonic(
-                    "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
-                ),
+                "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal",
+                "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush",
             ],
         }
 
@@ -438,68 +432,40 @@ def test_group_ems_mnemonics(monkeypatch):
             + mnemonics_extend_b,
             [],
         ),
-        complete = True,
     ):
         assert ems not in recovered
         recovered[ems] = groups
     assert len(recovered) == 2
     assert all(ems.decrypt(b"TREZOR") == MS for ems, _ in recovered.items())
-    print(
-        json.dumps(
-            {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
-        )
-    )
+    # print(
+    #     json.dumps(
+    #         {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+    #     )
+    # )
     assert recovered == {
         ems_MS_nonext: {
             0: [
-                Share.from_mnemonic(
-                    "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
-                )
+                "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
             ],
             1: [
-                Share.from_mnemonic(
-                    "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that"
-                ),
-                Share.from_mnemonic(
-                    "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught"
-                ),
-                Share.from_mnemonic(
-                    "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material"
-                ),
-                Share.from_mnemonic(
-                    "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal"
-                ),
-                Share.from_mnemonic(
-                    "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush"
-                ),
+                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that",
+                "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught",
+                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material",
+                "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush",
             ],
         },
         ems_MS_extend: {
             0: [
-                Share.from_mnemonic(
-                    "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
-                )
+                "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
             ],
             1: [
-                Share.from_mnemonic(
-                    "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music"
-                ),
-                Share.from_mnemonic(
-                    "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon"
-                ),
-                Share.from_mnemonic(
-                    "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf"
-                ),
-                Share.from_mnemonic(
-                    "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy"
-                ),
-                Share.from_mnemonic(
-                    "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
-                ),
+                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music",
+                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf",
+                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy",
+                "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy",
             ],
         },
     }
-
 
     # Let's test some groups of mnemonics from different seeds, but the same parameters.  Again, we
     # are suppressing entropy, so the only thing that will differ is the encryption of the seed; all
@@ -508,7 +474,11 @@ def test_group_ems_mnemonics(monkeypatch):
         MS, b"DIFFER", identifier=0, extendable=True, iteration_exponent=1
     )
     assert ems_MS_extend != ems_MS_extend_DIFFER
-    assert ems_MS_extend.decrypt(b"TREZOR") == ems_MS_extend_DIFFER.decrypt(b"DIFFER")== MS
+    assert (
+        ems_MS_extend.decrypt(b"TREZOR")
+        == ems_MS_extend_DIFFER.decrypt(b"DIFFER")
+        == MS
+    )
 
     # Produce SLIP-39 mnemonics for the alternatively encrypted (but identically parameterized) EMS
     mnemonics_extend_b_DIFFER = shamir.split_ems(
@@ -516,18 +486,21 @@ def test_group_ems_mnemonics(monkeypatch):
         [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
         ems_MS_extend_DIFFER,
     )
-    print( "MS w/ TREZOR:", json.dumps( mnemonics_extend_b, indent=4, default=str ))
-    print( "MS w/ DIFFER:", json.dumps( mnemonics_extend_b_DIFFER, indent=4, default=str ))
+    # print("MS w/ TREZOR:", json.dumps(mnemonics_extend_b, indent=4, default=str))
+    # print("MS w/ DIFFER:", json.dumps(mnemonics_extend_b_DIFFER, indent=4, default=str))
 
     import random
-    class ShareCorrupt( Share ):
-        def corrupt( self, bits=1 ) -> "Share":
+
+    class ShareCorrupt(Share):
+        def corrupt(self, bits=1) -> "Share":
             value_array = bytearray(self.value)
             pairs = set()
             while len(pairs) < bits:
-                pairs.add( (random.randint(0, len(value_array)-1), random.randint(0, 7)) )
-            for byte,bit in pairs:
-                value_array[byte] ^= (1 << bit)
+                pairs.add(
+                    (random.randint(0, len(value_array) - 1), random.randint(0, 7))
+                )
+            for byte, bit in pairs:
+                value_array[byte] ^= 1 << bit
             return Share(
                 self.identifier,
                 self.extendable,
@@ -537,55 +510,112 @@ def test_group_ems_mnemonics(monkeypatch):
                 self.group_count,
                 self.index,
                 self.member_threshold,
-                bytes(value_array)
+                bytes(value_array),
             )
 
-    def corrupt( share, bits=1 ):
+    def corrupt(share, bits=1):
         if isinstance(share, Share):
             share = share.mnemonic()
-        return (
-            ShareCorrupt
-            .from_mnemonic( share )
-            .corrupt( bits )
-            .mnemonic()
+        return ShareCorrupt.from_mnemonic(share).corrupt(bits).mnemonic()
+
+    # print(
+    #     corrupt(
+    #         "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
+    #     )
+    # )
+    assert (
+        corrupt(
+            "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy",
+            bits=0,
         )
-
-    print( corrupt(  "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy" ))
-    assert corrupt( "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy", bits=0 ) \
         == "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
-    assert corrupt( "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy" ) \
+    )
+    assert (
+        corrupt(
+            "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
+        )
         != "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy"
-
+    )
 
     # Now, attempt to recover.  Should regain both EMSs, even though all Shares have identical
     # parameters!!  Remember -- it is a /feature/ of SLIP-39 that an incorrect decryption key
     # results in a "valid" decrypted seed (just a seed that doesn't match the original).  So, see if
     # any decryption with the possible passwords correctly recovers the original seed...
     recovered = {}
-    shares = (
-        sum(
-            mnemonics_extend_b
-            + mnemonics_extend_b_DIFFER,
-            [],
+    shares = sum(
+        mnemonics_extend_b + mnemonics_extend_b_DIFFER,
+        [],
+    ) + list(
+        map(
+            corrupt,
+            sum(
+                mnemonics_extend_b,
+                [],
+            ),
         )
-        + list( map( corrupt, sum(
-            mnemonics_extend_b,
-            [],
-        )))
     )
-    print( "Mnemonics w/ TREZOR, DIFFER and corrupt sets:", json.dumps( shares, indent=4, default=str ))
+    # print(
+    #     "Mnemonics w/ TREZOR, DIFFER and corrupt sets:",
+    #     json.dumps(shares, indent=4, default=str),
+    # )
     for ems, groups in shamir.group_ems_mnemonics(
         shares,
-        complete = False,
+        complete=True,
     ):
         assert ems not in recovered
         recovered[ems] = groups
 
     assert len(recovered) == 2
-    print(
-        json.dumps(
-            {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
-        )
-    )
-    assert all( any( map( lambda p: ems.decrypt( p ) == MS, (b"TREZOR", b"DIFFER") )) for ems in recovered), \
-        "Failed to recover original seed w/ any valid password"
+    # print(
+    #     json.dumps(
+    #         {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+    #     )
+    # )
+    assert all(
+        any(map(lambda p: ems.decrypt(p) == MS, (b"TREZOR", b"DIFFER")))
+        for ems in recovered
+    ), "Failed to recover original seed w/ any valid password"
+
+    assert recovered == {
+        ems_MS_extend_DIFFER: {
+            0: [
+                "academic agency acrobat leader again gray increase worthy response music solution eraser squeeze cylinder acquire total music costume mountain snapshot"
+            ],
+            1: [
+                "academic agency beard leaf describe headset column cards steady secret plunge estate glad fused acquire glasses daughter fatigue acrobat famous",
+                "academic agency beard lily actress ruler fake camera skunk dryer boundary daughter dwarf crazy acne window blanket simple best leaves",
+                "academic agency beard lungs bucket cleanup smell plan valid corner result leaf style rainbow academic elbow survive grasp angry agency",
+                "academic agency beard marathon crush mayor relate plot timber source acrobat thunder lobe romp acid subject together wolf breathe sprinkle",
+                "academic agency beard merit cowboy view visual image skin adorn likely ladybug mouse merchant activity champion medal firm yelp lungs",
+            ],
+            2: [
+                "academic agency ceramic lips dream home born metric hearing exceed grasp raisin adult necklace adapt amazing estate math vitamins become",
+                "academic agency ceramic luxury duke manager brother vampire skin adorn likely ladybug mouse merchant activity champion medal enlarge loyalty skin",
+                "academic agency ceramic march adequate ticket auction general picture express tolerate silver multiple aluminum acne craft scandal divorce auction image",
+                "academic agency ceramic method document escape paces purple pitch famous wildlife language champion teaspoon activity perfect diagnose loud tension upstairs",
+                "academic agency ceramic mortgage alarm client lunch chemical satisfy carpet paid similar chemical jerky acne primary kind view hazard exceed",
+                "academic agency ceramic nervous again sack lobe elephant graduate extra jacket acquire race idea academic lily regular decent bulge merchant",
+            ],
+        },
+        ems_MS_extend: {
+            0: [
+                "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
+            ],
+            1: [
+                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music",
+                "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon",
+                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf",
+                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy",
+                "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy",
+            ],
+            2: [
+                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence",
+                "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal",
+                "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority",
+                "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar",
+                "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal",
+                "academic agency ceramic mortgage desert imply tenant package dream syndrome paid diet clothes cluster scout average depend fused cubic express",
+                "academic agency ceramic nervous calcium item graduate critical license darkness spine total fiber numb starting eraser justice that deny clothes",
+            ],
+        },
+    }

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -56,6 +56,78 @@ def test_iteration_exponent():
     assert MS != shamir.combine_mnemonics(mnemonics[1:4])
 
 
+def test_extendable_encryption_behavior():
+    """Test that the extendable parameter affects encryption determinism.
+
+    With extendable=False: same secret encrypted twice with different identifiers
+    produces different encrypted results, even with same passphrase.
+
+    With extendable=True: same secret always produces the same encrypted result
+    when using the same passphrase, regardless of identifier.
+    """
+    fixed_secret = b"ABCDEFGHIJKLMNOP"
+    passphrase1 = b"password1"
+    passphrase2 = b"password2"
+
+    # Test extendable=False behavior
+    # Same secret, same passphrase, different identifiers -> different encrypted results
+    ems_nonext_id1 = shamir.EncryptedMasterSecret.from_master_secret(
+        fixed_secret, passphrase1, identifier=1, extendable=False, iteration_exponent=1
+    )
+    ems_nonext_id1a = shamir.EncryptedMasterSecret.from_master_secret(
+        fixed_secret, passphrase1, identifier=1, extendable=False, iteration_exponent=1
+    )
+    ems_nonext_id2 = shamir.EncryptedMasterSecret.from_master_secret(
+        fixed_secret, passphrase1, identifier=2, extendable=False, iteration_exponent=1
+    )
+
+    # With extendable=False, the same encryption parameters produces the same ciphertext, and
+    # different identifier value produces *different* encrypted results
+    assert ems_nonext_id1.ciphertext == ems_nonext_id1a.ciphertext
+    assert ems_nonext_id1.ciphertext != ems_nonext_id2.ciphertext
+
+    # But both decrypt to the original secret with the correct passphrase
+    assert ems_nonext_id1.decrypt(passphrase1) == fixed_secret
+    assert ems_nonext_id2.decrypt(passphrase1) == fixed_secret
+
+    # With extendable=False and wrong passphrase, they decrypt to different (wrong) secrets.  This
+    # may be surprising; re-encoding the same master secret yields different custom/decoy wallets
+    # with each re-encoding.
+    wrong_secret1 = ems_nonext_id1.decrypt(passphrase2)
+    wrong_secret2 = ems_nonext_id2.decrypt(passphrase2)
+    assert wrong_secret1 != fixed_secret
+    assert wrong_secret2 != fixed_secret
+    assert wrong_secret1 != wrong_secret2  # Different wrong secrets
+
+    # Test extendable=True behavior
+    # Same secret, same passphrase, different identifiers -> same encrypted results
+    ems_ext_id1 = shamir.EncryptedMasterSecret.from_master_secret(
+        fixed_secret, passphrase1, identifier=1, extendable=True, iteration_exponent=1
+    )
+    ems_ext_id1a = shamir.EncryptedMasterSecret.from_master_secret(
+        fixed_secret, passphrase1, identifier=1, extendable=True, iteration_exponent=1
+    )
+    ems_ext_id2 = shamir.EncryptedMasterSecret.from_master_secret(
+        fixed_secret, passphrase1, identifier=2, extendable=True, iteration_exponent=1
+    )
+
+    # With extendable=True, the same encryption parameters produces the same ciphertext, and
+    # different identifier value now produces *the same* encrypted results
+    assert ems_ext_id1.ciphertext == ems_ext_id1a.ciphertext
+    assert ems_ext_id1.ciphertext == ems_ext_id2.ciphertext
+
+    # Both decrypt to the original secret with the correct passphrase
+    assert ems_ext_id1.decrypt(passphrase1) == fixed_secret
+    assert ems_ext_id2.decrypt(passphrase1) == fixed_secret
+
+    # With wrong passphrase, they decrypt to the same (wrong) secret
+    wrong_secret_ext1 = ems_ext_id1.decrypt(passphrase2)
+    wrong_secret_ext2 = ems_ext_id2.decrypt(passphrase2)
+    assert wrong_secret_ext1 != fixed_secret
+    assert wrong_secret_ext2 != fixed_secret
+    assert wrong_secret_ext1 == wrong_secret_ext2  # Same wrong secret
+
+
 def test_group_sharing():
     group_threshold = 2
     group_sizes = (5, 3, 5, 1)
@@ -292,7 +364,7 @@ def test_group_ems_mnemonics(monkeypatch):
     assert mnemonics_nonext_b[1] > mnemonics_nonext_a[1]
     assert mnemonics_nonext_b[2] > mnemonics_nonext_a[2]
 
-    # Now, generate an identically encrypted EMS (since we have eliminated all entropy), only differing in 'extenable'.
+    # Now, generate an identically encrypted EMS (since we have eliminated all entropy), only differing in 'extendable'.
     ems_MS_extend = shamir.EncryptedMasterSecret.from_master_secret(
         MS, b"TREZOR", identifier=0, extendable=True, iteration_exponent=1
     )

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -672,3 +672,97 @@ def test_group_ems_mnemonics(monkeypatch):
 
     assert len(recovered) == 2
     assert deepset(recovered) < expected
+
+
+def test_group_expand():
+    """Confirm that we can recover an EMS from a groups of SLIP-39 mnemonics, and "expand" those
+    groups to include more mnemonics compatible with the existing ones.
+
+    We'll use a pre-generated 2 of 1/1, 1/1, 2/4 and 3/6 grouping.
+
+    """
+    ones = b"\xff" * 16
+    ones_mnemonics = {
+        # First 1/1
+        0: {
+            "olympic guilt acrobat romp dining inform withdraw brave lips quarter bulge thorn best wildlife alive yelp home security lilac eclipse",
+        },
+        # Second 1/1
+        1: {
+            "olympic guilt beard romp apart preach various garden always mayor solution acid quantity domestic slush zero fatigue disaster fluff romp",
+        },
+        # Fam 2/4
+        2: {
+            "olympic guilt ceramic roster agency evidence beard emerald triumph crystal flip threaten yield slow dwarf mason together kidney center memory",
+            "olympic guilt ceramic scared dream shrimp upgrade flip scroll cylinder evaluate acquire evening idle omit learn impulse custody estimate blanket",
+            "olympic guilt ceramic shadow density false spark hesitate desert counter born omit smoking preach beyond dilemma aunt switch revenue peanut",
+            "olympic guilt ceramic sister angel speak deliver idea brave crazy aide isolate grasp birthday pulse domestic object market squeeze dismiss",
+        },
+        # Frens 3/6
+        3: {
+            "olympic guilt decision round animal velvet bedroom species railroad energy findings general laden estate music ordinary tolerate duration photo laden",
+            "olympic guilt decision scatter agency speak rapids quantity slice mustang fragment universe tackle screw wrist install moisture ticket founder display",
+            "olympic guilt decision shaft auction various lyrics amazing peasant withdraw editor swing makeup review analysis physics capacity marathon beaver divorce",
+            "olympic guilt decision skin acrobat spelling dance guest sugar crunch envy fancy cradle declare gasoline exceed hairy flash ugly language",
+            "olympic guilt decision snake costume teaspoon aluminum deadline steady cricket subject bedroom acrobat elbow numb material scatter dramatic capture advance",
+            "olympic guilt decision spider coastal round promise expect paper width spelling ounce party smart username grin provide tracks theater engage",
+        },
+    }
+
+    # We can recover the original "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong" =~=
+    # 0xffffffffffffffffffffffffffffffff seed and all of the supplied mnemonics are valid and
+    # recovered (when 'complete')
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(*ones_mnemonics.values()), complete=True
+    )
+    assert ems.decrypt(b"") == ones
+    assert recovered == ones_mnemonics
+
+    # Now, lets only supply the Fam and Frens, and ensure we can get back the 1/1 shares
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(ones_mnemonics[2], ones_mnemonics[3])
+    )
+    assert ems.decrypt(b"") == ones
+    assert deepset(recovered) < ones_mnemonics
+    assert 0 not in recovered  # First (group 0) but not recovered
+
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(ones_mnemonics[2], ones_mnemonics[3]),
+        expand=[(0, 1)],
+    )
+    assert ems.decrypt(b"") == ones
+    assert deepset(recovered) < ones_mnemonics
+    assert recovered[0] == {
+        "olympic guilt acrobat romp dining inform withdraw brave lips quarter bulge thorn best wildlife alive yelp home security lilac eclipse",
+    }
+    assert 1 not in recovered
+
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(ones_mnemonics[2], ones_mnemonics[3]),
+        expand=[(0, 1), (1, 1)],
+    )
+    assert ems.decrypt(b"") == ones
+    assert deepset(recovered) <= ones_mnemonics
+    assert recovered[0] == {
+        "olympic guilt acrobat romp dining inform withdraw brave lips quarter bulge thorn best wildlife alive yelp home security lilac eclipse",
+    }
+    assert recovered[1] == {
+        "olympic guilt beard romp apart preach various garden always mayor solution acid quantity domestic slush zero fatigue disaster fluff romp",
+    }
+
+    # OK, we've recovered 2 1/1 groups.  Now, lets see if we can expand an existing threshold/count
+    # group to increase the group's member count.  Let's increase Frens from a 3/6 to a larger 3/10
+    ((ems, recovered),) = shamir.group_ems_mnemonics(
+        set.union(ones_mnemonics[0], ones_mnemonics[3]),
+        expand=[(3, 10)],
+    )
+    assert ems.decrypt(b"") == ones
+    assert not deepset(recovered) <= ones_mnemonics  # No longer a subset!
+    assert (
+        deepset(ones_mnemonics[3]) < recovered[3]
+    )  # In fact, original group 3 is now a subset!
+    print(
+        json.dumps(
+            {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
+        )
+    )

--- a/test_shamir.py
+++ b/test_shamir.py
@@ -1,10 +1,12 @@
 import json
+import random
 import secrets
 from itertools import combinations
 from random import shuffle
 
 import pytest
 from bip32utils import BIP32Key
+from deepset import deepset
 
 import shamir_mnemonic as shamir
 from shamir_mnemonic import MnemonicError, Share
@@ -408,13 +410,13 @@ def test_group_ems_mnemonics(monkeypatch):
         assert ems.decrypt(b"TREZOR") == MS
 
         assert groups == {
-            0: [
+            0: {
                 "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
-            ],
-            1: [
+            },
+            1: {
                 "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal",
                 "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush",
-            ],
+            },
         }
 
     # Here, we'll recover both unique EncryptedMasterSecret values with unique common_parameters
@@ -423,6 +425,7 @@ def test_group_ems_mnemonics(monkeypatch):
     # iterate over all combinations and cartesion products of available share groups to try to
     # recover any SLIP-39 encoded EncryptedMasterSecret values available.  It will ignore any
     # invalid, redundant or incomplete mnemonics.
+
     recovered = {}
     for ems, groups in shamir.group_ems_mnemonics(
         sum(
@@ -432,9 +435,11 @@ def test_group_ems_mnemonics(monkeypatch):
             + mnemonics_extend_b,
             [],
         ),
+        complete=True,
     ):
         assert ems not in recovered
         recovered[ems] = groups
+
     assert len(recovered) == 2
     assert all(ems.decrypt(b"TREZOR") == MS for ems, _ in recovered.items())
     # print(
@@ -442,30 +447,68 @@ def test_group_ems_mnemonics(monkeypatch):
     #         {str(ems): group for ems, group in recovered.items()}, indent=4, default=str
     #     )
     # )
-    assert recovered == {
+    expected = {
         ems_MS_nonext: {
-            0: [
+            0: {
                 "academic acid acrobat leader civil gross counter dictate fancy findings lair freshman kind justice apart quiet lunch short vitamins painting"
-            ],
-            1: [
-                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that",
-                "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught",
-                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material",
+            },
+            1: {
                 "academic acid beard merit calcium music reaction says swimming rhythm member carbon regret daisy vintage gravity pile crisis estimate crush",
-            ],
+                "academic acid beard marathon criminal force perfect being dwarf energy scroll satoshi welfare lunar slush charity guilt briefing steady medal",
+                "academic acid beard lily dwarf aide unknown fancy merit grant sharp leaves blimp exotic sharp fancy salon forecast worthy taught",
+                "academic acid beard leaf desktop crowd erode vegan season warmth warn craft ceramic picture wrote depend radar result dream that",
+                "academic acid beard lungs center injury academic pupal hand surface volume have smart hormone wealthy echo capture year browser material",
+            },
+            2: {
+                "academic acid ceramic mortgage ancient beard duration wolf beam smirk ultimate helpful amuse rapids item election plastic library voting orange",
+                "academic acid ceramic luxury acquire gross likely very swimming rhythm member carbon regret daisy vintage gravity pile arena quiet material",
+                "academic acid ceramic lips dress custody tension wildlife forbid surprise ticket already ugly emerald laundry pickup deny exhaust cards orange",
+                "academic acid ceramic nervous devote force galaxy veteran much priority losing injury frost swimming vegan learn dress ruler formal material",
+                "academic acid ceramic method diet drift sweater alto epidemic beyond analysis hearing timber vegan alto tidy obtain ceramic cricket sack",
+                "academic acid ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic ugly saver sack",
+                "academic acid ceramic march dream estimate genuine ambition listen gesture harvest broken fiction hawk making safari mountain problem hospital snake",
+            },
         },
         ems_MS_extend: {
-            0: [
+            0: {
                 "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
-            ],
-            1: [
-                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music",
-                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf",
-                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy",
+            },
+            1: {
                 "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy",
-            ],
+                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf",
+                "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon",
+                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music",
+                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy",
+            },
+            2: {
+                "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal",
+                "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar",
+                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence",
+                "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority",
+                "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal",
+                "academic agency ceramic mortgage desert imply tenant package dream syndrome paid diet clothes cluster scout average depend fused cubic express",
+                "academic agency ceramic nervous calcium item graduate critical license darkness spine total fiber numb starting eraser justice that deny clothes",
+            },
         },
     }
+    assert deepset(recovered) == expected
+
+    # And again, with complete=False
+    recovered = {}
+    for ems, groups in shamir.group_ems_mnemonics(
+        sum(
+            mnemonics_nonext_a
+            + mnemonics_nonext_b
+            + mnemonics_extend_a
+            + mnemonics_extend_b,
+            [],
+        ),
+        complete=False,
+    ):
+        assert ems not in recovered
+        recovered[ems] = groups
+    assert len(recovered) == 2
+    assert deepset(recovered) <= expected
 
     # Let's test some groups of mnemonics from different seeds, but the same parameters.  Again, we
     # are suppressing entropy, so the only thing that will differ is the encryption of the seed; all
@@ -486,10 +529,6 @@ def test_group_ems_mnemonics(monkeypatch):
         [(1, 1), (2, 5), (3, 7)],  # <-- increase group member count
         ems_MS_extend_DIFFER,
     )
-    # print("MS w/ TREZOR:", json.dumps(mnemonics_extend_b, indent=4, default=str))
-    # print("MS w/ DIFFER:", json.dumps(mnemonics_extend_b_DIFFER, indent=4, default=str))
-
-    import random
 
     class ShareCorrupt(Share):
         def corrupt(self, bits=1) -> "Share":
@@ -541,7 +580,6 @@ def test_group_ems_mnemonics(monkeypatch):
     # parameters!!  Remember -- it is a /feature/ of SLIP-39 that an incorrect decryption key
     # results in a "valid" decrypted seed (just a seed that doesn't match the original).  So, see if
     # any decryption with the possible passwords correctly recovers the original seed...
-    recovered = {}
     shares = sum(
         mnemonics_extend_b + mnemonics_extend_b_DIFFER,
         [],
@@ -558,6 +596,7 @@ def test_group_ems_mnemonics(monkeypatch):
     #     "Mnemonics w/ TREZOR, DIFFER and corrupt sets:",
     #     json.dumps(shares, indent=4, default=str),
     # )
+    recovered = {}
     for ems, groups in shamir.group_ems_mnemonics(
         shares,
         complete=True,
@@ -576,46 +615,60 @@ def test_group_ems_mnemonics(monkeypatch):
         for ems in recovered
     ), "Failed to recover original seed w/ any valid password"
 
-    assert recovered == {
-        ems_MS_extend_DIFFER: {
-            0: [
-                "academic agency acrobat leader again gray increase worthy response music solution eraser squeeze cylinder acquire total music costume mountain snapshot"
-            ],
-            1: [
-                "academic agency beard leaf describe headset column cards steady secret plunge estate glad fused acquire glasses daughter fatigue acrobat famous",
-                "academic agency beard lily actress ruler fake camera skunk dryer boundary daughter dwarf crazy acne window blanket simple best leaves",
-                "academic agency beard lungs bucket cleanup smell plan valid corner result leaf style rainbow academic elbow survive grasp angry agency",
-                "academic agency beard marathon crush mayor relate plot timber source acrobat thunder lobe romp acid subject together wolf breathe sprinkle",
-                "academic agency beard merit cowboy view visual image skin adorn likely ladybug mouse merchant activity champion medal firm yelp lungs",
-            ],
-            2: [
-                "academic agency ceramic lips dream home born metric hearing exceed grasp raisin adult necklace adapt amazing estate math vitamins become",
-                "academic agency ceramic luxury duke manager brother vampire skin adorn likely ladybug mouse merchant activity champion medal enlarge loyalty skin",
-                "academic agency ceramic march adequate ticket auction general picture express tolerate silver multiple aluminum acne craft scandal divorce auction image",
-                "academic agency ceramic method document escape paces purple pitch famous wildlife language champion teaspoon activity perfect diagnose loud tension upstairs",
-                "academic agency ceramic mortgage alarm client lunch chemical satisfy carpet paid similar chemical jerky acne primary kind view hazard exceed",
-                "academic agency ceramic nervous again sack lobe elephant graduate extra jacket acquire race idea academic lily regular decent bulge merchant",
-            ],
-        },
+    expected = {
         ems_MS_extend: {
-            0: [
+            0: {
                 "academic agency acrobat leader check clinic isolate slavery branch bulge hairy library emphasis slim fused both cargo predator network adult"
-            ],
-            1: [
-                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music",
-                "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon",
-                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf",
-                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy",
+            },
+            1: {
                 "academic agency beard merit distance welfare survive sniff damage husband knife evening gross garlic check result extend estate agency destroy",
-            ],
-            2: [
-                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence",
-                "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal",
-                "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority",
-                "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar",
+                "academic agency beard lungs cinema device true move texture obesity freshman jury should sack froth custody froth race finance dwarf",
+                "academic agency beard lily armed tadpole scroll dynamic security unwrap exercise require busy busy firefly drink item column costume nylon",
+                "academic agency beard leaf both husky alarm firefly obtain device response graduate bedroom flash luxury friendly grasp slice robin music",
+                "academic agency beard marathon display oasis crowd wits rhyme eclipse problem pecan security main license exclude editor fumes salary deploy",
+            },
+            2: {
                 "academic agency ceramic method change magazine exhaust forecast priority fused pink presence demand webcam violence visual crowd tendency declare coastal",
+                "academic agency ceramic march counter ancestor lizard railroad river usual estate software improve river behavior emperor envy elevator genre scholar",
+                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence",
+                "academic agency ceramic luxury drove vampire criminal idea damage husband knife evening gross garlic check result extend work keyboard priority",
+                "academic agency ceramic lips blind wireless process scramble military lecture diploma nylon birthday talent deal wealthy briefing edge geology scandal",
                 "academic agency ceramic mortgage desert imply tenant package dream syndrome paid diet clothes cluster scout average depend fused cubic express",
                 "academic agency ceramic nervous calcium item graduate critical license darkness spine total fiber numb starting eraser justice that deny clothes",
-            ],
+            },
+        },
+        ems_MS_extend_DIFFER: {
+            0: {
+                "academic agency acrobat leader again gray increase worthy response music solution eraser squeeze cylinder acquire total music costume mountain snapshot"
+            },
+            1: {
+                "academic agency beard merit cowboy view visual image skin adorn likely ladybug mouse merchant activity champion medal firm yelp lungs",
+                "academic agency beard lungs bucket cleanup smell plan valid corner result leaf style rainbow academic elbow survive grasp angry agency",
+                "academic agency beard lily actress ruler fake camera skunk dryer boundary daughter dwarf crazy acne window blanket simple best leaves",
+                "academic agency beard leaf describe headset column cards steady secret plunge estate glad fused acquire glasses daughter fatigue acrobat famous",
+                "academic agency beard marathon crush mayor relate plot timber source acrobat thunder lobe romp acid subject together wolf breathe sprinkle",
+            },
+            2: {
+                "academic agency ceramic method document escape paces purple pitch famous wildlife language champion teaspoon activity perfect diagnose loud tension upstairs",
+                "academic agency ceramic learn academic academic academic academic academic academic academic academic academic academic academic academic academic zero laundry presence",
+                "academic agency ceramic lips dream home born metric hearing exceed grasp raisin adult necklace adapt amazing estate math vitamins become",
+                "academic agency ceramic march adequate ticket auction general picture express tolerate silver multiple aluminum acne craft scandal divorce auction image",
+                "academic agency ceramic luxury duke manager brother vampire skin adorn likely ladybug mouse merchant activity champion medal enlarge loyalty skin",
+                "academic agency ceramic mortgage alarm client lunch chemical satisfy carpet paid similar chemical jerky acne primary kind view hazard exceed",
+                "academic agency ceramic nervous again sack lobe elephant graduate extra jacket acquire race idea academic lily regular decent bulge merchant",
+            },
         },
     }
+    assert deepset(recovered) <= expected
+
+    # And again, with complete=False
+    recovered = {}
+    for ems, groups in shamir.group_ems_mnemonics(
+        shares,
+        complete=False,
+    ):
+        assert ems not in recovered
+        recovered[ems] = groups
+
+    assert len(recovered) == 2
+    assert deepset(recovered) <= expected


### PR DESCRIPTION
Recovering SLIP-39 EncryptedMasterSecrets from (possibly corrupted or otherwise attacked) sets of Mnemonics is the sole purpose of the SLIP-39 standard.

Verifying, grouping and vetting sets of mnemonics requires at least partial decoding of the mnemonic to extract identifier, extendable flag, group counts, thresholds, etc., so that only compatible mnemonics are considered.  This is difficult to do "externally" to the SLIP-39 implementation.

Therefore, a robust API to recover one or more SLIP-39-encoded encrypted master secrets from a pool of collected mnemonics is not just useful, but critical to the proper operation of a SLIP-39 based recovery system.

Thus: I propose `shamir_mnemonic.group_ems_mnemonics`, which takes a sequence of Mnemonics (as either `str` or `Share`), and produces a sequence of EncryptedMasterSecrets and a dict of  group indices and the list of Mnemonics used to recover the secret.  It does so in a manner resilient to various corruptions or attacks, ignoring invalid, unrelated/incompatible or redundant Mnemonics.

Fixes #44 

Furthermore, `group_ems_mnemonics` provides the ability to optionally `expand` 1 or more groups with additional mnemonics, or even replace a failed mnemonic group with a single-Share mnemonic.  This allows recovery from SLIP-39 group failures (too many lost mnemonics), by:
- recovering the group using existing mnemonics (if sufficient) and re-generating the missing ones, or
- producing new ones compatible with the existing mnemonics to issue to new group participants, or
- replacing (or augmenting) the failed group with a new single-Share (1 of 1) mnemonic for the group.

All of these approaches are supported by the existing underlying cryptography of SLIP-39, assume no new extensions to the protocol, and will work with any set of existing SLIP-39 mnemonics.