### PR TITLE
Include license-file metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.3.1"
 description = "SLIP-39 Shamir Mnemonics"
 authors = ["Trezor <info@trezor.io>"]
 license = "MIT"
+license-files = ["LICENSE"]
 readme = [
     "README.rst",
     "CHANGELOG.rst",


### PR DESCRIPTION
This meta-data will be picked up by automation tools used for building RPM packages for Fedora Linux